### PR TITLE
Add cached speech bubble overlays

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -83,6 +83,10 @@ func (g *Game) DrawOverlay(screen *render.Image) {
 	g.modes.DrawOverlay(screen)
 }
 
+func (g *Game) DrawUIOverlay(screen *render.Image) {
+	g.modes.DrawUIOverlay(screen)
+}
+
 func (g *Game) Resize(width, height int) {
 	if width <= 0 || height <= 0 {
 		g.screenW = g.cfg.Window.Width

--- a/app/app.go
+++ b/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"image/color"
 	"log"
 	"time"
 
@@ -34,7 +33,6 @@ type Game struct {
 	started  time.Time
 	screenW  int
 	screenH  int
-	fpsText  string
 	quit     func()
 	quitting bool
 }
@@ -83,7 +81,6 @@ func (g *Game) Draw(screen *render.Image) {
 
 func (g *Game) DrawOverlay(screen *render.Image) {
 	g.modes.DrawOverlay(screen)
-	g.drawFPSCounter(screen)
 }
 
 func (g *Game) Resize(width, height int) {
@@ -98,19 +95,6 @@ func (g *Game) Resize(width, height int) {
 
 func (g *Game) InputState() *input.State {
 	return g.input
-}
-
-func (g *Game) SetFPSCounter(text string) {
-	g.fpsText = text
-}
-
-func (g *Game) drawFPSCounter(screen *render.Image) {
-	if screen == nil || g.fpsText == "" {
-		return
-	}
-	textW, textH := render.DebugTextSize(g.fpsText)
-	render.DrawRect(screen, 6, 6, float64(textW+8), float64(textH+6), color.RGBA{R: 0, G: 0, B: 0, A: 170})
-	render.DebugPrintAtColor(screen, g.fpsText, 10, 9, color.RGBA{R: 224, G: 255, B: 190, A: 255})
 }
 
 func (g *Game) SetQuitFunc(quit func()) {

--- a/game/actor.go
+++ b/game/actor.go
@@ -217,6 +217,7 @@ func (m *WorldMode) applyActorVanish(ctx client.Context, vanish network.ActorVan
 	delete(m.actorDeaths, vanish.ID)
 	delete(m.actorSoundFrames, vanish.ID)
 	delete(m.actorLife, vanish.ID)
+	delete(m.speechBubbles, vanish.ID)
 }
 
 func (m *WorldMode) cleanupDeadActors(ctx client.Context, now time.Time) {
@@ -233,6 +234,7 @@ func (m *WorldMode) cleanupDeadActors(ctx client.Context, now time.Time) {
 		delete(m.actorAnims, id)
 		delete(m.actorSoundFrames, id)
 		delete(m.actorLife, id)
+		delete(m.speechBubbles, id)
 		if m.pendingAttack.targetID == id {
 			m.pendingAttack = attackIntent{}
 		}
@@ -504,6 +506,7 @@ func (m *WorldMode) drawSceneActorOverlays(screen *render.Image, ctx client.Cont
 	}
 	m.drawAttackFocusMarker(screen, ctx, now, entries)
 	m.drawVendingBoardLabels(screen, ctx, entries)
+	m.drawSpeechBubbles(screen, entries, now)
 	m.drawHoveredLocalPlayerNameLabel(screen, ctx, entries)
 	m.drawHoveredActorNameLabel(screen, ctx, projection, now)
 }

--- a/game/actor.go
+++ b/game/actor.go
@@ -1034,13 +1034,7 @@ func drawActorNameLabelAtY(screen *render.Image, label string, centerX, labelY f
 		return
 	}
 	outline := color.RGBA{A: 196}
-	text := render.OutlinedTextImage(label, foreground, outline)
-	if text == nil {
-		return
-	}
-	x := int(math.Round(centerX)) - text.Bounds().Dx()/2
-	y := int(math.Round(labelY))
-	render.DrawOutlinedTextAt(screen, label, x, y, foreground, outline)
+	render.DrawCenteredUIOutlinedTextAt(screen, label, centerX, labelY, foreground, outline)
 }
 
 func actorSpriteTopY(baseY, scale float64) float64 {

--- a/game/battle.go
+++ b/game/battle.go
@@ -1522,10 +1522,10 @@ func (m *WorldMode) drawActorLifeBar(screen *render.Image, ctx client.Context, e
 	} else if ratio < 0.25 {
 		fill = color.RGBA{R: 255, G: 255, B: 0, A: 255}
 	}
-	render.DrawRect(screen, x, y, width, height, color.RGBA{R: 16, G: 24, B: 156, A: 255})
-	render.DrawRect(screen, x+1, y+1, width-2, height-2, color.RGBA{R: 66, G: 66, B: 66, A: 255})
+	render.DrawUIRect(screen, x, y, width, height, color.RGBA{R: 16, G: 24, B: 156, A: 255})
+	render.DrawUIRect(screen, x+1, y+1, width-2, height-2, color.RGBA{R: 66, G: 66, B: 66, A: 255})
 	if fillWidth > 0 {
-		render.DrawRect(screen, x+1, y+1, fillWidth, 3, fill)
+		render.DrawUIRect(screen, x+1, y+1, fillWidth, 3, fill)
 	}
 	if life.hasSP {
 		spRatio := float64(life.sp) / float64(life.maxSP)
@@ -1534,9 +1534,9 @@ func (m *WorldMode) drawActorLifeBar(screen *render.Image, ctx client.Context, e
 		} else if spRatio > 1 {
 			spRatio = 1
 		}
-		render.DrawRect(screen, x, y+4, width, 1, color.RGBA{R: 16, G: 24, B: 156, A: 255})
+		render.DrawUIRect(screen, x, y+4, width, 1, color.RGBA{R: 16, G: 24, B: 156, A: 255})
 		if spWidth := math.Round((width - 2) * spRatio); spWidth > 0 {
-			render.DrawRect(screen, x+1, y+5, spWidth, 3, gameui.PlayerSPBarColor)
+			render.DrawUIRect(screen, x+1, y+5, spWidth, 3, gameui.PlayerSPBarColor)
 		}
 	}
 }

--- a/game/battle.go
+++ b/game/battle.go
@@ -1522,10 +1522,10 @@ func (m *WorldMode) drawActorLifeBar(screen *render.Image, ctx client.Context, e
 	} else if ratio < 0.25 {
 		fill = color.RGBA{R: 255, G: 255, B: 0, A: 255}
 	}
-	render.DrawUIRect(screen, x, y, width, height, color.RGBA{R: 16, G: 24, B: 156, A: 255})
-	render.DrawUIRect(screen, x+1, y+1, width-2, height-2, color.RGBA{R: 66, G: 66, B: 66, A: 255})
+	render.DrawRect(screen, x, y, width, height, color.RGBA{R: 16, G: 24, B: 156, A: 255})
+	render.DrawRect(screen, x+1, y+1, width-2, height-2, color.RGBA{R: 66, G: 66, B: 66, A: 255})
 	if fillWidth > 0 {
-		render.DrawUIRect(screen, x+1, y+1, fillWidth, 3, fill)
+		render.DrawRect(screen, x+1, y+1, fillWidth, 3, fill)
 	}
 	if life.hasSP {
 		spRatio := float64(life.sp) / float64(life.maxSP)
@@ -1534,9 +1534,9 @@ func (m *WorldMode) drawActorLifeBar(screen *render.Image, ctx client.Context, e
 		} else if spRatio > 1 {
 			spRatio = 1
 		}
-		render.DrawUIRect(screen, x, y+4, width, 1, color.RGBA{R: 16, G: 24, B: 156, A: 255})
+		render.DrawRect(screen, x, y+4, width, 1, color.RGBA{R: 16, G: 24, B: 156, A: 255})
 		if spWidth := math.Round((width - 2) * spRatio); spWidth > 0 {
-			render.DrawUIRect(screen, x+1, y+5, spWidth, 3, gameui.PlayerSPBarColor)
+			render.DrawRect(screen, x+1, y+5, spWidth, 3, gameui.PlayerSPBarColor)
 		}
 	}
 }

--- a/game/manager.go
+++ b/game/manager.go
@@ -16,6 +16,10 @@ type overlayMode interface {
 	DrawOverlay(client.Context, *render.Image)
 }
 
+type uiOverlayMode interface {
+	DrawUIOverlay(client.Context, *render.Image)
+}
+
 type Manager struct {
 	ctx  client.Context
 	mode Mode
@@ -58,5 +62,11 @@ func (m *Manager) Draw(screen *render.Image) {
 func (m *Manager) DrawOverlay(screen *render.Image) {
 	if mode, ok := m.mode.(overlayMode); ok {
 		mode.DrawOverlay(m.ctx, screen)
+	}
+}
+
+func (m *Manager) DrawUIOverlay(screen *render.Image) {
+	if mode, ok := m.mode.(uiOverlayMode); ok {
+		mode.DrawUIOverlay(m.ctx, screen)
 	}
 }

--- a/game/speech_bubbles.go
+++ b/game/speech_bubbles.go
@@ -1,0 +1,114 @@
+package game
+
+import (
+	"strings"
+	"time"
+
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/network"
+	"github.com/kivutar/goro/render"
+)
+
+const (
+	speechBubbleBaseDuration = 3500 * time.Millisecond
+	speechBubblePerRune      = 40 * time.Millisecond
+	speechBubbleMaxDuration  = 8500 * time.Millisecond
+	speechBubbleMaxWidth     = 220
+)
+
+type speechBubble struct {
+	text    string
+	expires time.Time
+}
+
+func (m *WorldMode) applySpeechBubble(ctx client.Context, chat network.ChatMessage, now time.Time) {
+	if strings.TrimSpace(chat.Text) == "" {
+		return
+	}
+	text := speechBubbleText(chat.Text)
+	if text == "" {
+		return
+	}
+	actorIDs := speechBubbleActorIDs(ctx, chat)
+	if len(actorIDs) == 0 {
+		return
+	}
+	if m.speechBubbles == nil {
+		m.speechBubbles = make(map[uint32]speechBubble)
+	}
+	duration := speechBubbleBaseDuration + time.Duration(len([]rune(text)))*speechBubblePerRune
+	if duration > speechBubbleMaxDuration {
+		duration = speechBubbleMaxDuration
+	}
+	for _, actorID := range actorIDs {
+		if actorID == 0 {
+			continue
+		}
+		m.speechBubbles[actorID] = speechBubble{
+			text:    text,
+			expires: now.Add(duration),
+		}
+	}
+}
+
+func speechBubbleActorIDs(ctx client.Context, chat network.ChatMessage) []uint32 {
+	if chat.GID != 0 {
+		ids := []uint32{chat.GID}
+		if ctx.Session != nil {
+			if chat.GID == ctx.Session.AccountID && ctx.Session.CharID != 0 {
+				ids = append(ids, ctx.Session.CharID)
+			} else if chat.GID == ctx.Session.CharID && ctx.Session.AccountID != 0 {
+				ids = append(ids, ctx.Session.AccountID)
+			}
+		}
+		return ids
+	}
+	name, _, ok := strings.Cut(strings.TrimSpace(chat.Text), " : ")
+	if !ok || ctx.Session == nil {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(name), selectedCharacterName(ctx.Session)) {
+		return nil
+	}
+	ids := make([]uint32, 0, 2)
+	if ctx.Session.CharID != 0 {
+		ids = append(ids, ctx.Session.CharID)
+	}
+	if ctx.Session.AccountID != 0 {
+		ids = append(ids, ctx.Session.AccountID)
+	}
+	return ids
+}
+
+func speechBubbleText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if _, message, ok := strings.Cut(text, " : "); ok {
+		return strings.TrimSpace(message)
+	}
+	return text
+}
+
+func (m *WorldMode) drawSpeechBubbles(screen *render.Image, entries []sceneActorDrawEntry, now time.Time) {
+	if len(m.speechBubbles) == 0 {
+		return
+	}
+	for id, bubble := range m.speechBubbles {
+		if now.After(bubble.expires) {
+			delete(m.speechBubbles, id)
+		}
+	}
+	if len(m.speechBubbles) == 0 {
+		return
+	}
+	for _, entry := range entries {
+		bubble, ok := m.speechBubbles[entry.actor.ID]
+		if !ok || strings.TrimSpace(bubble.text) == "" {
+			continue
+		}
+		bottomY := actorSpriteTopY(entry.screenY, entry.scale) - 6
+		render.DrawUISpeechBubble(screen, bubble.text, entry.screenX, bottomY, speechBubbleMaxWidth)
+	}
+}

--- a/game/speech_bubbles_test.go
+++ b/game/speech_bubbles_test.go
@@ -1,0 +1,32 @@
+package game
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/network"
+	"github.com/kivutar/goro/session"
+)
+
+func TestSpeechBubbleTextUsesMessagePart(t *testing.T) {
+	if got := speechBubbleText("Kivutar : hello there"); got != "hello there" {
+		t.Fatalf("speechBubbleText = %q, want hello there", got)
+	}
+}
+
+func TestApplySpeechBubbleUsesLocalActorIDsForLocalEcho(t *testing.T) {
+	mode := NewWorldMode()
+	ctx := client.Context{Session: &session.Session{
+		AccountID: 2000000,
+		CharID:    150000,
+		Selected:  session.Character{ID: 150000, Name: "Kivutar"},
+	}}
+	mode.applySpeechBubble(ctx, network.ChatMessage{Text: "Kivutar : hello"}, time.Now())
+	if mode.speechBubbles[150000].text != "hello" {
+		t.Fatalf("char bubble = %+v, want hello", mode.speechBubbles[150000])
+	}
+	if mode.speechBubbles[2000000].text != "hello" {
+		t.Fatalf("account bubble = %+v, want hello", mode.speechBubbles[2000000])
+	}
+}

--- a/game/world.go
+++ b/game/world.go
@@ -1518,6 +1518,13 @@ func (m *WorldMode) DrawOverlay(ctx client.Context, screen *render.Image) {
 	}
 }
 
+func (m *WorldMode) DrawUIOverlay(ctx client.Context, screen *render.Image) {
+	if ctx.Config.Render.NoUI {
+		return
+	}
+	m.shortcutBar.DrawTooltip(screen, ctx)
+}
+
 func (m *WorldMode) drawUIDragGhosts(screen *render.Image, ctx client.Context) {
 	m.inventoryBag.DrawDragGhost(screen, ctx, m)
 	m.storageWindow.DrawDragGhost(screen, ctx, m)

--- a/game/world.go
+++ b/game/world.go
@@ -90,6 +90,7 @@ type WorldMode struct {
 	actorSoundFrames  map[uint32]actorSoundFrame
 	actorLife         map[uint32]actorLife
 	actorNameReqAt    map[uint32]time.Time
+	speechBubbles     map[uint32]speechBubble
 	gndNormalSource   *res.GND
 	gndTopNormals     [][4]modelPoint3
 	minimap           gameui.Minimap
@@ -270,6 +271,7 @@ func (m *WorldMode) Enter(ctx client.Context) {
 	m.actorDeaths = make(map[uint32]time.Time)
 	m.actorSoundFrames = make(map[uint32]actorSoundFrame)
 	m.actorLife = make(map[uint32]actorLife)
+	m.speechBubbles = make(map[uint32]speechBubble)
 	m.syncCurrentActorEffectStateEffects(ctx)
 	m.shortcutBar.Load(ctx)
 	m.npcDialog.ResetPublished(ctx)
@@ -387,6 +389,7 @@ func (m *WorldMode) Update(ctx client.Context) (Mode, error) {
 		if chat, ok, err := network.ParseChatMessage(pkt); err != nil {
 			log.Printf("parse chat message 0x%04X: %v", pkt.ID, err)
 		} else if ok {
+			m.applySpeechBubble(ctx, chat, now)
 			addConsoleMessage(&m.console, ctx.Resources, chat)
 			continue
 		}

--- a/game/world.go
+++ b/game/world.go
@@ -1522,6 +1522,8 @@ func (m *WorldMode) DrawUIOverlay(ctx client.Context, screen *render.Image) {
 	if ctx.Config.Render.NoUI {
 		return
 	}
+	m.inventoryBag.DrawTooltip(screen, ctx)
+	m.equipmentWindow.DrawTooltip(screen, ctx)
 	m.shortcutBar.DrawTooltip(screen, ctx)
 }
 

--- a/render/backend.go
+++ b/render/backend.go
@@ -72,6 +72,10 @@ type overlayDrawer interface {
 	DrawOverlay(*Image)
 }
 
+type uiOverlayDrawer interface {
+	DrawUIOverlay(*Image)
+}
+
 type runtimeSettingsProvider interface {
 	RuntimeFullscreen() bool
 	RuntimeVSync() bool
@@ -89,8 +93,6 @@ type runner struct {
 	ui              *uiapp.App
 	uiCanvas        *ggcanvas.Canvas
 	uiImage         *Image
-	fpsCanvas       *ggcanvas.Canvas
-	fpsImage        *Image
 	uiOverlayCanvas *ggcanvas.Canvas
 	uiTextCache     map[string]cachedOverlayImage
 	uiBubbleCache   map[string]cachedOverlayImage
@@ -113,7 +115,6 @@ type runner struct {
 	fpsDisplay      float64
 	frameMSDisplay  float64
 	fpsText         string
-	fpsScale        float64
 	uiOverlayScale  float64
 	quit            func()
 	cpuProfile      *os.File
@@ -211,10 +212,6 @@ func Run(game Game, cfg config.WindowConfig, renderCfg config.RenderConfig) erro
 		if r.uiCanvas != nil {
 			_ = r.uiCanvas.Close()
 			r.uiCanvas = nil
-		}
-		if r.fpsCanvas != nil {
-			_ = r.fpsCanvas.Close()
-			r.fpsCanvas = nil
 		}
 		if r.uiOverlayCanvas != nil {
 			_ = r.uiOverlayCanvas.Close()
@@ -592,6 +589,12 @@ func (r *runner) draw(ctx *gogpu.Context) error {
 	if err := r.drawUI(r.screen, width, height, deviceScale); err != nil {
 		return err
 	}
+	if drawer, ok := r.game.(uiOverlayDrawer); ok {
+		drawer.DrawUIOverlay(r.screen)
+		if err := r.drawUIOverlay(r.screen, deviceScale); err != nil {
+			return err
+		}
+	}
 	if drawer, ok := r.game.(overlayDrawer); ok {
 		drawer.DrawOverlay(r.screen)
 	}
@@ -721,9 +724,10 @@ func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
 }
 
 func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
-	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiSpeechBubbles) == 0 && len(screen.uiTextLabels) == 0) {
+	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiSpeechBubbles) == 0 && len(screen.uiTextLabels) == 0 && len(screen.uiTooltips) == 0) {
 		return nil
 	}
+	defer screen.clearUIOverlayCommands()
 	provider := r.app.GPUContextProvider()
 	if provider == nil {
 		return nil
@@ -759,7 +763,39 @@ func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
 		}
 		drawCachedOverlayImage(screen, cached, x, label.Y)
 	}
+	for _, tooltip := range screen.uiTooltips {
+		cached, err := r.cachedTooltipImage(provider, tooltip, deviceScale)
+		if err != nil {
+			return err
+		}
+		screenW, screenH := screen.Bounds().Dx(), screen.Bounds().Dy()
+		x := tooltip.CenterX - float64(cached.width)/2
+		y := tooltip.BelowY
+		if y+float64(cached.height)+8 > float64(screenH) && tooltip.AboveY > 0 {
+			y = tooltip.AboveY - float64(cached.height)
+		}
+		x = clampOverlayFloat64(x, 8, maxOverlayFloat64(8, float64(screenW-cached.width-8)))
+		y = clampOverlayFloat64(y, 8, maxOverlayFloat64(8, float64(screenH-cached.height-8)))
+		drawCachedOverlayImage(screen, cached, x, y)
+	}
 	return nil
+}
+
+func clampOverlayFloat64(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func maxOverlayFloat64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func drawCachedOverlayImage(screen *Image, cached cachedOverlayImage, x, y float64) {
@@ -845,15 +881,51 @@ func (r *runner) cachedSpeechBubbleImage(provider gpucontext.DeviceProvider, bub
 	if maxWidth <= 0 {
 		maxWidth = 220
 	}
-	const (
-		size     float32 = 11
-		lineH    float32 = 14
-		padX     float32 = 7
-		padY     float32 = 5
-		minWidth float32 = 28
-		maxLines         = 4
-	)
 	key := fmt.Sprintf("bubble|%.3f|%.1f|%s", deviceScale, maxWidth, text)
+	style := consoleOverlayTextBoxStyle()
+	style.minWidth = 28
+	style.maxWidth = maxWidth
+	style.maxLines = 4
+	style.wrap = true
+	return r.cachedOverlayTextBoxImage(provider, key, text, deviceScale, style)
+}
+
+func (r *runner) cachedTooltipImage(provider gpucontext.DeviceProvider, tooltip UITooltipCommand, deviceScale float64) (cachedOverlayImage, error) {
+	text := strings.TrimSpace(tooltip.Text)
+	if text == "" {
+		return cachedOverlayImage{}, nil
+	}
+	key := fmt.Sprintf("tooltip|%.3f|%s", deviceScale, text)
+	return r.cachedOverlayTextBoxImage(provider, key, text, deviceScale, consoleOverlayTextBoxStyle())
+}
+
+type overlayTextBoxStyle struct {
+	size       float32
+	lineH      float32
+	padX       float32
+	padY       float32
+	minWidth   float32
+	maxWidth   float32
+	maxLines   int
+	wrap       bool
+	background widget.Color
+	foreground widget.Color
+}
+
+func consoleOverlayTextBoxStyle() overlayTextBoxStyle {
+	return overlayTextBoxStyle{
+		size:       rotheme.Default.Typography.TextSize,
+		lineH:      14,
+		padX:       8,
+		padY:       6,
+		minWidth:   1,
+		maxLines:   1,
+		background: widget.RGBA8(14, 18, 24, 188),
+		foreground: widget.RGBA8(235, 242, 250, 255),
+	}
+}
+
+func (r *runner) cachedOverlayTextBoxImage(provider gpucontext.DeviceProvider, key, text string, deviceScale float64, style overlayTextBoxStyle) (cachedOverlayImage, error) {
 	if cached, ok := r.uiBubbleCache[key]; ok {
 		return cached, nil
 	}
@@ -861,32 +933,40 @@ func (r *runner) cachedSpeechBubbleImage(provider gpucontext.DeviceProvider, bub
 	if err != nil {
 		return cachedOverlayImage{}, err
 	}
-	var lines []string
+	lines := []string{text}
 	if err := measure.Draw(func(cc *gg.Context) {
 		canvas := uirender.NewCanvas(cc, 1, 1)
-		lines = wrapOverlayText(canvas, text, size, false, maxWidth-padX*2)
+		if style.wrap {
+			lines = wrapOverlayText(canvas, text, style.size, false, style.maxWidth-style.padX*2)
+		}
 	}); err != nil {
-		return cachedOverlayImage{}, fmt.Errorf("measure speech bubble overlay: %w", err)
+		return cachedOverlayImage{}, fmt.Errorf("measure text box overlay: %w", err)
 	}
-	if len(lines) > maxLines {
-		lines = append(lines[:maxLines-1], ellipsizeOverlayText(measure, strings.Join(lines[maxLines-1:], " "), size, false, maxWidth-padX*2))
+	if len(lines) == 0 {
+		lines = []string{text}
+	}
+	if style.maxLines > 0 && len(lines) > style.maxLines {
+		lines = append(lines[:style.maxLines-1], ellipsizeOverlayText(measure, strings.Join(lines[style.maxLines-1:], " "), style.size, false, style.maxWidth-style.padX*2))
 	}
 	textWidth := float32(0)
 	if err := measure.Draw(func(cc *gg.Context) {
 		canvas := uirender.NewCanvas(cc, 1, 1)
 		for _, line := range lines {
-			if w := rotheme.MeasureText(canvas, line, size, false); w > textWidth {
+			if w := rotheme.MeasureText(canvas, line, style.size, false); w > textWidth {
 				textWidth = w
 			}
 		}
 	}); err != nil {
-		return cachedOverlayImage{}, fmt.Errorf("measure speech bubble width: %w", err)
+		return cachedOverlayImage{}, fmt.Errorf("measure text box width: %w", err)
 	}
-	width := int(maxFloat32(minWidth, textWidth+padX*2) + 0.999)
-	if width > int(maxWidth) {
-		width = int(maxWidth)
+	width := int(maxFloat32(style.minWidth, textWidth+style.padX*2) + 0.999)
+	if style.maxWidth > 0 && width > int(style.maxWidth) {
+		width = int(style.maxWidth)
 	}
-	height := int(float32(len(lines))*lineH + padY*2 + 0.999)
+	if width < 1 {
+		width = 1
+	}
+	height := int(float32(len(lines))*style.lineH + style.padY*2 + 0.999)
 	canvas, err := r.ensureOverlayCanvas(provider, width, height, deviceScale)
 	if err != nil {
 		return cachedOverlayImage{}, err
@@ -898,17 +978,16 @@ func (r *runner) cachedSpeechBubbleImage(provider gpucontext.DeviceProvider, bub
 			textMode.SetTextMode(widget.TextModeVector)
 			defer textMode.SetTextMode(widget.TextModeAuto)
 		}
-		uiCanvas.DrawRect(geometry.NewRect(0, 0, float32(width), float32(height)), widget.RGBA8(0, 0, 0, 170))
-		fg := widget.RGBA8(255, 255, 255, 255)
+		uiCanvas.DrawRect(geometry.NewRect(0, 0, float32(width), float32(height)), style.background)
 		for i, line := range lines {
-			y := padY + float32(i)*lineH
-			rotheme.DrawText(uiCanvas, line, geometry.NewRect(padX, y, float32(width)-padX*2, lineH), size, fg, false, widget.TextAlignLeft)
+			y := style.padY + float32(i)*style.lineH
+			rotheme.DrawText(uiCanvas, line, geometry.NewRect(style.padX, y, float32(width)-style.padX*2, style.lineH), style.size, style.foreground, false, widget.TextAlignLeft)
 		}
 	}); err != nil {
-		return cachedOverlayImage{}, fmt.Errorf("draw speech bubble overlay: %w", err)
+		return cachedOverlayImage{}, fmt.Errorf("draw text box overlay: %w", err)
 	}
 	if _, err := canvas.Flush(); err != nil {
-		return cachedOverlayImage{}, fmt.Errorf("flush speech bubble overlay: %w", err)
+		return cachedOverlayImage{}, fmt.Errorf("flush text box overlay: %w", err)
 	}
 	cached := cachedOverlayImage{image: updateCanvasImage(canvas, nil), width: width, height: height}
 	if r.uiBubbleCache == nil {
@@ -1037,53 +1116,10 @@ func (r *runner) drawFPSMeter(screen *Image, deviceScale float64) error {
 	if deviceScale <= 0 {
 		deviceScale = 1
 	}
-	const canvasW, canvasH = 180, 22
-	if r.fpsCanvas == nil {
-		canvas, err := ggcanvas.NewWithScale(provider, canvasW, canvasH, deviceScale)
-		if err != nil {
-			return fmt.Errorf("create fps canvas: %w", err)
-		}
-		r.fpsCanvas = canvas
-		r.fpsScale = deviceScale
+	cached, err := r.cachedOverlayTextBoxImage(provider, fmt.Sprintf("fps|%.3f|%s", deviceScale, r.fpsText), r.fpsText, deviceScale, consoleOverlayTextBoxStyle())
+	if err != nil {
+		return fmt.Errorf("draw fps overlay: %w", err)
 	}
-	if r.fpsScale != deviceScale {
-		r.fpsCanvas.SetDeviceScale(deviceScale)
-		r.fpsScale = deviceScale
-		r.fpsImage = nil
-	}
-	if err := r.fpsCanvas.Draw(func(cc *gg.Context) {
-		canvas := uirender.NewCanvas(cc, canvasW, canvasH)
-		canvas.Clear(widget.RGBA8(0, 0, 0, 0))
-		if textMode, ok := canvas.(widget.TextModeController); ok {
-			textMode.SetTextMode(widget.TextModeVector)
-			defer textMode.SetTextMode(widget.TextModeAuto)
-		}
-		const h float32 = 20
-		textW := rotheme.MeasureText(canvas, r.fpsText, rotheme.Default.Typography.TextSize, false)
-		w := textW + 10
-		if w < 1 {
-			w = 1
-		}
-		bg := widget.RGBA8(0, 0, 0, 170)
-		fg := widget.RGBA8(224, 255, 190, 255)
-		canvas.DrawRect(geometry.NewRect(0, 0, w, h), bg)
-		rotheme.DrawText(canvas, r.fpsText, geometry.NewRect(5, 3, w-10, 14), rotheme.Default.Typography.TextSize, fg, false, widget.TextAlignLeft)
-	}); err != nil {
-		return fmt.Errorf("draw fps canvas: %w", err)
-	}
-	if _, err := r.fpsCanvas.Flush(); err != nil {
-		return fmt.Errorf("flush fps canvas: %w", err)
-	}
-	r.fpsImage = updateCanvasImage(r.fpsCanvas, r.fpsImage)
-	if r.fpsImage == nil {
-		return nil
-	}
-	var opts DrawImageOptions
-	if b := r.fpsImage.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
-		opts.GeoM.Scale(float64(canvasW)/float64(b.Dx()), float64(canvasH)/float64(b.Dy()))
-	}
-	opts.GeoM.Translate(6, 6)
-	opts.Filter = FilterNearest
-	screen.DrawImage(r.fpsImage, &opts)
+	drawCachedOverlayImage(screen, cached, 6, 6)
 	return nil
 }

--- a/render/backend.go
+++ b/render/backend.go
@@ -14,6 +14,7 @@ import (
 	gogputypes "github.com/gogpu/gogpu/gpu/types"
 	"github.com/gogpu/gpucontext"
 	uiapp "github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/geometry"
 	uirender "github.com/gogpu/ui/render"
 	"github.com/gogpu/ui/widget"
 	"github.com/kivutar/goro/client"
@@ -76,15 +77,13 @@ type runtimeSettingsProvider interface {
 	RuntimeFPS() bool
 }
 
-type fpsCounterReceiver interface {
-	SetFPSCounter(string)
-}
-
 type runner struct {
 	app            *gogpu.App
 	ui             *uiapp.App
 	uiCanvas       *ggcanvas.Canvas
 	uiImage        *Image
+	fpsCanvas      *ggcanvas.Canvas
+	fpsImage       *Image
 	game           Game
 	screen         *Image
 	gpu            *gpuRenderer
@@ -103,6 +102,8 @@ type runner struct {
 	fpsFrames      int64
 	fpsDisplay     float64
 	frameMSDisplay float64
+	fpsText        string
+	fpsScale       float64
 	quit           func()
 	cpuProfile     *os.File
 	fullscreen     bool
@@ -199,6 +200,10 @@ func Run(game Game, cfg config.WindowConfig, renderCfg config.RenderConfig) erro
 		if r.uiCanvas != nil {
 			_ = r.uiCanvas.Close()
 			r.uiCanvas = nil
+		}
+		if r.fpsCanvas != nil {
+			_ = r.fpsCanvas.Close()
+			r.fpsCanvas = nil
 		}
 	})
 	return gg.Run()
@@ -524,6 +529,7 @@ func (r *runner) applyRuntimeSettings() {
 		r.fpsFrames = 0
 		r.fpsDisplay = 0
 		r.frameMSDisplay = 0
+		r.fpsText = ""
 	}
 	if vsync := provider.RuntimeVSync(); vsync != r.vsync {
 		r.vsync = vsync
@@ -564,13 +570,15 @@ func (r *runner) draw(ctx *gogpu.Context) error {
 	}
 	r.screen.BeginFrame()
 	r.screen.SetScreenScale(scaleX, scaleY)
-	r.publishFPSCounter()
 	r.game.Draw(r.screen)
 	if err := r.drawUI(r.screen, width, height, deviceScale); err != nil {
 		return err
 	}
 	if drawer, ok := r.game.(overlayDrawer); ok {
 		drawer.DrawOverlay(r.screen)
+	}
+	if err := r.drawFPSMeter(r.screen, deviceScale); err != nil {
+		return err
 	}
 	if err := r.gpu.Draw(ctx, r.screen); err != nil {
 		return err
@@ -667,18 +675,22 @@ func (r *runner) drawUI(screen *Image, width, height int, deviceScale float64) e
 }
 
 func (r *runner) updateUIImage() {
-	if r.uiCanvas == nil || r.uiCanvas.Context() == nil {
-		return
+	r.uiImage = updateCanvasImage(r.uiCanvas, r.uiImage)
+}
+
+func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
+	if canvas == nil || canvas.Context() == nil {
+		return dstImage
 	}
-	src := r.uiCanvas.Context().ResizeTarget().ImageView()
+	src := canvas.Context().ResizeTarget().ImageView()
 	if src == nil {
-		return
+		return dstImage
 	}
 	width, height := src.Bounds().Dx(), src.Bounds().Dy()
-	if r.uiImage == nil || r.uiImage.pix == nil || r.uiImage.Bounds().Dx() != width || r.uiImage.Bounds().Dy() != height {
-		r.uiImage = NewImage(width, height)
+	if dstImage == nil || dstImage.pix == nil || dstImage.Bounds().Dx() != width || dstImage.Bounds().Dy() != height {
+		dstImage = NewImage(width, height)
 	}
-	dst := r.uiImage.pix
+	dst := dstImage.pix
 	if src.Stride == width*4 && dst.Stride == width*4 {
 		copy(dst.Pix, src.Pix)
 	} else {
@@ -686,7 +698,8 @@ func (r *runner) updateUIImage() {
 			copy(dst.Pix[y*dst.Stride:y*dst.Stride+width*4], src.Pix[y*src.Stride:y*src.Stride+width*4])
 		}
 	}
-	r.uiImage.version++
+	dstImage.version++
+	return dstImage
 }
 
 func (r *runner) updateFPSCounter(now time.Time) {
@@ -695,6 +708,7 @@ func (r *runner) updateFPSCounter(now time.Time) {
 	}
 	if r.fpsStarted.IsZero() {
 		r.fpsStarted = now
+		r.fpsText = "FPS --"
 		return
 	}
 	r.fpsFrames++
@@ -707,20 +721,67 @@ func (r *runner) updateFPSCounter(now time.Time) {
 	r.frameMSDisplay = seconds * 1000 / float64(r.fpsFrames)
 	r.fpsFrames = 0
 	r.fpsStarted = now
+	r.fpsText = fmt.Sprintf("FPS %.1f  %.2f ms", r.fpsDisplay, r.frameMSDisplay)
 }
 
-func (r *runner) publishFPSCounter() {
-	receiver, ok := r.game.(fpsCounterReceiver)
-	if !ok {
-		return
+func (r *runner) drawFPSMeter(screen *Image, deviceScale float64) error {
+	if !r.renderCfg.FPS || r.fpsText == "" || screen == nil {
+		return nil
 	}
-	if !r.renderCfg.FPS {
-		receiver.SetFPSCounter("")
-		return
+	provider := r.app.GPUContextProvider()
+	if provider == nil {
+		return nil
 	}
-	text := "FPS --"
-	if r.fpsDisplay > 0 {
-		text = fmt.Sprintf("FPS %.1f  %.2f ms", r.fpsDisplay, r.frameMSDisplay)
+	if deviceScale <= 0 {
+		deviceScale = 1
 	}
-	receiver.SetFPSCounter(text)
+	const canvasW, canvasH = 180, 22
+	if r.fpsCanvas == nil {
+		canvas, err := ggcanvas.NewWithScale(provider, canvasW, canvasH, deviceScale)
+		if err != nil {
+			return fmt.Errorf("create fps canvas: %w", err)
+		}
+		r.fpsCanvas = canvas
+		r.fpsScale = deviceScale
+	}
+	if r.fpsScale != deviceScale {
+		r.fpsCanvas.SetDeviceScale(deviceScale)
+		r.fpsScale = deviceScale
+		r.fpsImage = nil
+	}
+	if err := r.fpsCanvas.Draw(func(cc *gg.Context) {
+		canvas := uirender.NewCanvas(cc, canvasW, canvasH)
+		canvas.Clear(widget.RGBA8(0, 0, 0, 0))
+		if textMode, ok := canvas.(widget.TextModeController); ok {
+			textMode.SetTextMode(widget.TextModeVector)
+			defer textMode.SetTextMode(widget.TextModeAuto)
+		}
+		const h float32 = 20
+		textW := rotheme.MeasureText(canvas, r.fpsText, rotheme.Default.Typography.TextSize, false)
+		w := textW + 10
+		if w < 1 {
+			w = 1
+		}
+		bg := widget.RGBA8(0, 0, 0, 170)
+		fg := widget.RGBA8(224, 255, 190, 255)
+		canvas.DrawRect(geometry.NewRect(0, 0, w, h), bg)
+		rotheme.DrawText(canvas, r.fpsText, geometry.NewRect(5, 3, w-10, 14), rotheme.Default.Typography.TextSize, fg, false, widget.TextAlignLeft)
+	}); err != nil {
+		return fmt.Errorf("draw fps canvas: %w", err)
+	}
+	if _, err := r.fpsCanvas.Flush(); err != nil {
+		return fmt.Errorf("flush fps canvas: %w", err)
+	}
+	r.fpsImage = updateCanvasImage(r.fpsCanvas, r.fpsImage)
+	if r.fpsImage == nil {
+		return nil
+	}
+	var opts DrawImageOptions
+	if b := r.fpsImage.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
+		opts.GeoM.Scale(float64(canvasW)/float64(b.Dx()), float64(canvasH)/float64(b.Dy()))
+	}
+	opts.GeoM.Translate(6, 6)
+	opts.Filter = FilterNearest
+	screen.DrawImage(r.fpsImage, &opts)
+	return nil
 }

--- a/render/backend.go
+++ b/render/backend.go
@@ -3,7 +3,6 @@ package render
 import (
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"runtime/pprof"
 	"strings"
@@ -79,42 +78,43 @@ type runtimeSettingsProvider interface {
 }
 
 type runner struct {
-	app            *gogpu.App
-	ui             *uiapp.App
-	uiCanvas       *ggcanvas.Canvas
-	uiImage        *Image
-	fpsCanvas      *ggcanvas.Canvas
-	fpsImage       *Image
-	textLabels     map[string]*uiTextLabelTexture
-	game           Game
-	screen         *Image
-	gpu            *gpuRenderer
-	width          int
-	height         int
-	duration       time.Duration
-	warmup         time.Duration
-	renderCfg      config.RenderConfig
-	started        time.Time
-	measureStarted time.Time
-	lastLog        time.Time
-	lastFrame      int64
-	frames         int64
-	measuredFrames int64
-	fpsStarted     time.Time
-	fpsFrames      int64
-	fpsDisplay     float64
-	frameMSDisplay float64
-	fpsText        string
-	fpsScale       float64
-	textLabelScale float64
-	quit           func()
-	cpuProfile     *os.File
-	fullscreen     bool
-	vsync          bool
-	fps            bool
-	vsyncWarned    bool
-	uiDrawnOnce    bool
-	uiScale        float64
+	app             *gogpu.App
+	ui              *uiapp.App
+	uiCanvas        *ggcanvas.Canvas
+	uiImage         *Image
+	fpsCanvas       *ggcanvas.Canvas
+	fpsImage        *Image
+	uiOverlayCanvas *ggcanvas.Canvas
+	uiOverlayImage  *Image
+	game            Game
+	screen          *Image
+	gpu             *gpuRenderer
+	width           int
+	height          int
+	duration        time.Duration
+	warmup          time.Duration
+	renderCfg       config.RenderConfig
+	started         time.Time
+	measureStarted  time.Time
+	lastLog         time.Time
+	lastFrame       int64
+	frames          int64
+	measuredFrames  int64
+	fpsStarted      time.Time
+	fpsFrames       int64
+	fpsDisplay      float64
+	frameMSDisplay  float64
+	fpsText         string
+	fpsScale        float64
+	uiOverlayScale  float64
+	quit            func()
+	cpuProfile      *os.File
+	fullscreen      bool
+	vsync           bool
+	fps             bool
+	vsyncWarned     bool
+	uiDrawnOnce     bool
+	uiScale         float64
 }
 
 func Run(game Game, cfg config.WindowConfig, renderCfg config.RenderConfig) error {
@@ -208,7 +208,10 @@ func Run(game Game, cfg config.WindowConfig, renderCfg config.RenderConfig) erro
 			_ = r.fpsCanvas.Close()
 			r.fpsCanvas = nil
 		}
-		r.closeTextLabelTextures()
+		if r.uiOverlayCanvas != nil {
+			_ = r.uiOverlayCanvas.Close()
+			r.uiOverlayCanvas = nil
+		}
 	})
 	return gg.Run()
 }
@@ -575,7 +578,7 @@ func (r *runner) draw(ctx *gogpu.Context) error {
 	r.screen.BeginFrame()
 	r.screen.SetScreenScale(scaleX, scaleY)
 	r.game.Draw(r.screen)
-	if err := r.drawUITextLabels(r.screen, deviceScale); err != nil {
+	if err := r.drawUIOverlay(r.screen, deviceScale); err != nil {
 		return err
 	}
 	if err := r.drawUI(r.screen, width, height, deviceScale); err != nil {
@@ -709,15 +712,8 @@ func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
 	return dstImage
 }
 
-type uiTextLabelTexture struct {
-	canvas *ggcanvas.Canvas
-	image  *Image
-	width  int
-	height int
-}
-
-func (r *runner) drawUITextLabels(screen *Image, deviceScale float64) error {
-	if screen == nil || len(screen.uiTextLabels) == 0 {
+func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
+	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiTextLabels) == 0) {
 		return nil
 	}
 	provider := r.app.GPUContextProvider()
@@ -727,146 +723,91 @@ func (r *runner) drawUITextLabels(screen *Image, deviceScale float64) error {
 	if deviceScale <= 0 {
 		deviceScale = 1
 	}
-	if r.textLabelScale != deviceScale {
-		r.closeTextLabelTextures()
-		r.textLabelScale = deviceScale
+	width, height := screen.Bounds().Dx(), screen.Bounds().Dy()
+	if width <= 0 || height <= 0 {
+		return nil
 	}
-	for _, label := range screen.uiTextLabels {
-		texture, err := r.uiTextLabelTexture(provider, deviceScale, label)
+	if r.uiOverlayCanvas == nil {
+		canvas, err := ggcanvas.NewWithScale(provider, width, height, deviceScale)
 		if err != nil {
-			return err
+			return fmt.Errorf("create ui overlay canvas: %w", err)
 		}
-		if texture == nil || texture.image == nil {
-			continue
+		r.uiOverlayCanvas = canvas
+		r.uiOverlayScale = deviceScale
+	}
+	canvasW, canvasH := r.uiOverlayCanvas.Size()
+	if canvasW != width || canvasH != height {
+		if err := r.uiOverlayCanvas.Resize(width, height); err != nil {
+			return fmt.Errorf("resize ui overlay canvas: %w", err)
 		}
-		x := label.X
-		if label.Centered {
-			x -= float64(texture.width) / 2
-		}
-		var opts DrawImageOptions
-		if b := texture.image.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
-			opts.GeoM.Scale(float64(texture.width)/float64(b.Dx()), float64(texture.height)/float64(b.Dy()))
-		}
-		opts.GeoM.Translate(math.Round(x), math.Round(label.Y))
-		opts.Filter = FilterNearest
-		screen.DrawImage(texture.image, &opts)
+		r.uiOverlayImage = nil
 	}
-	return nil
-}
-
-func (r *runner) uiTextLabelTexture(provider gpucontext.DeviceProvider, deviceScale float64, label UITextLabelCommand) (*uiTextLabelTexture, error) {
-	key := uiTextLabelKey(label)
-	if texture := r.textLabels[key]; texture != nil {
-		return texture, nil
+	if r.uiOverlayScale != deviceScale {
+		r.uiOverlayCanvas.SetDeviceScale(deviceScale)
+		r.uiOverlayScale = deviceScale
+		r.uiOverlayImage = nil
 	}
-	if r.textLabels == nil {
-		r.textLabels = make(map[string]*uiTextLabelTexture)
-	}
-	size := label.Size
-	if size <= 0 {
-		size = rotheme.Default.Typography.TextSize
-	}
-	textW, err := r.measureUITextLabelWidth(provider, deviceScale, label, size)
-	if err != nil {
-		return nil, err
-	}
-	width := int(math.Ceil(float64(textW))) + 6
-	if width < 24 {
-		width = 24
-	}
-	height := int(math.Ceil(float64(size))) + 10
-	if height < 18 {
-		height = 18
-	}
-	canvas, err := ggcanvas.NewWithScale(provider, width, height, deviceScale)
-	if err != nil {
-		return nil, fmt.Errorf("create text label canvas: %w", err)
-	}
-	texture := &uiTextLabelTexture{canvas: canvas, width: width, height: height}
-	if err := canvas.Draw(func(cc *gg.Context) {
+	if err := r.uiOverlayCanvas.Draw(func(cc *gg.Context) {
 		uiCanvas := uirender.NewCanvas(cc, width, height)
 		uiCanvas.Clear(widget.RGBA8(0, 0, 0, 0))
 		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
 			textMode.SetTextMode(widget.TextModeVector)
 			defer textMode.SetTextMode(widget.TextModeAuto)
 		}
-		drawOutlinedUIText(uiCanvas, label, width, height, size)
-	}); err != nil {
-		_ = canvas.Close()
-		return nil, fmt.Errorf("draw text label canvas: %w", err)
-	}
-	if _, err := canvas.Flush(); err != nil {
-		_ = canvas.Close()
-		return nil, fmt.Errorf("flush text label canvas: %w", err)
-	}
-	texture.image = updateCanvasImage(canvas, nil)
-	r.textLabels[key] = texture
-	r.trimTextLabelTextures()
-	return texture, nil
-}
-
-func (r *runner) measureUITextLabelWidth(provider gpucontext.DeviceProvider, deviceScale float64, label UITextLabelCommand, size float32) (float32, error) {
-	canvas, err := ggcanvas.NewWithScale(provider, 1, 1, deviceScale)
-	if err != nil {
-		return 0, fmt.Errorf("create text label measure canvas: %w", err)
-	}
-	defer canvas.Close()
-	var width float32
-	if err := canvas.Draw(func(cc *gg.Context) {
-		uiCanvas := uirender.NewCanvas(cc, 1, 1)
-		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
-			textMode.SetTextMode(widget.TextModeVector)
-			defer textMode.SetTextMode(widget.TextModeAuto)
+		for _, rect := range screen.uiRects {
+			uiCanvas.DrawRect(
+				geometry.NewRect(float32(rect.X), float32(rect.Y), float32(rect.W), float32(rect.H)),
+				widget.RGBA8(rect.Color.R, rect.Color.G, rect.Color.B, rect.Color.A),
+			)
 		}
-		width = rotheme.MeasureText(uiCanvas, label.Text, size, label.Bold)
+		for _, label := range screen.uiTextLabels {
+			drawOutlinedUIText(uiCanvas, label)
+		}
 	}); err != nil {
-		return 0, fmt.Errorf("measure text label: %w", err)
+		return fmt.Errorf("draw ui overlay canvas: %w", err)
 	}
-	return width, nil
+	if _, err := r.uiOverlayCanvas.Flush(); err != nil {
+		return fmt.Errorf("flush ui overlay canvas: %w", err)
+	}
+	r.uiOverlayImage = updateCanvasImage(r.uiOverlayCanvas, r.uiOverlayImage)
+	if r.uiOverlayImage == nil {
+		return nil
+	}
+	var opts DrawImageOptions
+	if b := r.uiOverlayImage.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
+		opts.GeoM.Scale(float64(width)/float64(b.Dx()), float64(height)/float64(b.Dy()))
+	}
+	opts.Filter = FilterNearest
+	screen.DrawImage(r.uiOverlayImage, &opts)
+	return nil
 }
 
-func drawOutlinedUIText(canvas widget.Canvas, label UITextLabelCommand, width, height int, size float32) {
+func drawOutlinedUIText(canvas widget.Canvas, label UITextLabelCommand) {
+	size := label.Size
+	if size <= 0 {
+		size = rotheme.Default.Typography.TextSize
+	}
+	textW := rotheme.MeasureText(canvas, label.Text, size, label.Bold)
+	x := float32(label.X)
+	if label.Centered {
+		x -= textW / 2
+	}
+	y := float32(label.Y)
+	width := textW + 4
+	if width < 4 {
+		width = 4
+	}
+	height := size + 8
+	if height < 16 {
+		height = 16
+	}
 	fg := widget.RGBA8(label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A)
 	outline := widget.RGBA8(label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A)
-	bounds := geometry.NewRect(2, 2, float32(width-4), float32(height-4))
+	bounds := geometry.NewRect(x+2, y+2, width, height)
 	for _, offset := range [][2]float32{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
 		rotheme.DrawText(canvas, label.Text, bounds.TranslateXY(offset[0], offset[1]), size, outline, label.Bold, widget.TextAlignLeft)
 	}
 	rotheme.DrawText(canvas, label.Text, bounds, size, fg, label.Bold, widget.TextAlignLeft)
-}
-
-func uiTextLabelKey(label UITextLabelCommand) string {
-	return fmt.Sprintf("%s|%d|%d|%d|%d|%d|%d|%d|%d|%.1f|%t",
-		label.Text,
-		label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A,
-		label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A,
-		label.Size,
-		label.Bold,
-	)
-}
-
-func (r *runner) trimTextLabelTextures() {
-	if len(r.textLabels) <= 256 {
-		return
-	}
-	for key, texture := range r.textLabels {
-		if texture != nil && texture.canvas != nil {
-			_ = texture.canvas.Close()
-		}
-		delete(r.textLabels, key)
-		if len(r.textLabels) <= 192 {
-			return
-		}
-	}
-}
-
-func (r *runner) closeTextLabelTextures() {
-	for key, texture := range r.textLabels {
-		if texture != nil && texture.canvas != nil {
-			_ = texture.canvas.Close()
-		}
-		delete(r.textLabels, key)
-	}
 }
 
 func (r *runner) updateFPSCounter(now time.Time) {

--- a/render/backend.go
+++ b/render/backend.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"runtime/pprof"
 	"strings"
@@ -84,6 +85,7 @@ type runner struct {
 	uiImage        *Image
 	fpsCanvas      *ggcanvas.Canvas
 	fpsImage       *Image
+	textLabels     map[string]*uiTextLabelTexture
 	game           Game
 	screen         *Image
 	gpu            *gpuRenderer
@@ -104,6 +106,7 @@ type runner struct {
 	frameMSDisplay float64
 	fpsText        string
 	fpsScale       float64
+	textLabelScale float64
 	quit           func()
 	cpuProfile     *os.File
 	fullscreen     bool
@@ -205,6 +208,7 @@ func Run(game Game, cfg config.WindowConfig, renderCfg config.RenderConfig) erro
 			_ = r.fpsCanvas.Close()
 			r.fpsCanvas = nil
 		}
+		r.closeTextLabelTextures()
 	})
 	return gg.Run()
 }
@@ -577,6 +581,9 @@ func (r *runner) draw(ctx *gogpu.Context) error {
 	if drawer, ok := r.game.(overlayDrawer); ok {
 		drawer.DrawOverlay(r.screen)
 	}
+	if err := r.drawUITextLabels(r.screen, deviceScale); err != nil {
+		return err
+	}
 	if err := r.drawFPSMeter(r.screen, deviceScale); err != nil {
 		return err
 	}
@@ -700,6 +707,166 @@ func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
 	}
 	dstImage.version++
 	return dstImage
+}
+
+type uiTextLabelTexture struct {
+	canvas *ggcanvas.Canvas
+	image  *Image
+	width  int
+	height int
+}
+
+func (r *runner) drawUITextLabels(screen *Image, deviceScale float64) error {
+	if screen == nil || len(screen.uiTextLabels) == 0 {
+		return nil
+	}
+	provider := r.app.GPUContextProvider()
+	if provider == nil {
+		return nil
+	}
+	if deviceScale <= 0 {
+		deviceScale = 1
+	}
+	if r.textLabelScale != deviceScale {
+		r.closeTextLabelTextures()
+		r.textLabelScale = deviceScale
+	}
+	for _, label := range screen.uiTextLabels {
+		texture, err := r.uiTextLabelTexture(provider, deviceScale, label)
+		if err != nil {
+			return err
+		}
+		if texture == nil || texture.image == nil {
+			continue
+		}
+		x := label.X
+		if label.Centered {
+			x -= float64(texture.width) / 2
+		}
+		var opts DrawImageOptions
+		if b := texture.image.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
+			opts.GeoM.Scale(float64(texture.width)/float64(b.Dx()), float64(texture.height)/float64(b.Dy()))
+		}
+		opts.GeoM.Translate(math.Round(x), math.Round(label.Y))
+		opts.Filter = FilterNearest
+		screen.DrawImage(texture.image, &opts)
+	}
+	return nil
+}
+
+func (r *runner) uiTextLabelTexture(provider gpucontext.DeviceProvider, deviceScale float64, label UITextLabelCommand) (*uiTextLabelTexture, error) {
+	key := uiTextLabelKey(label)
+	if texture := r.textLabels[key]; texture != nil {
+		return texture, nil
+	}
+	if r.textLabels == nil {
+		r.textLabels = make(map[string]*uiTextLabelTexture)
+	}
+	size := label.Size
+	if size <= 0 {
+		size = rotheme.Default.Typography.TextSize
+	}
+	textW, err := r.measureUITextLabelWidth(provider, deviceScale, label, size)
+	if err != nil {
+		return nil, err
+	}
+	width := int(math.Ceil(float64(textW))) + 6
+	if width < 24 {
+		width = 24
+	}
+	height := int(math.Ceil(float64(size))) + 10
+	if height < 18 {
+		height = 18
+	}
+	canvas, err := ggcanvas.NewWithScale(provider, width, height, deviceScale)
+	if err != nil {
+		return nil, fmt.Errorf("create text label canvas: %w", err)
+	}
+	texture := &uiTextLabelTexture{canvas: canvas, width: width, height: height}
+	if err := canvas.Draw(func(cc *gg.Context) {
+		uiCanvas := uirender.NewCanvas(cc, width, height)
+		uiCanvas.Clear(widget.RGBA8(0, 0, 0, 0))
+		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
+			textMode.SetTextMode(widget.TextModeVector)
+			defer textMode.SetTextMode(widget.TextModeAuto)
+		}
+		drawOutlinedUIText(uiCanvas, label, width, height, size)
+	}); err != nil {
+		_ = canvas.Close()
+		return nil, fmt.Errorf("draw text label canvas: %w", err)
+	}
+	if _, err := canvas.Flush(); err != nil {
+		_ = canvas.Close()
+		return nil, fmt.Errorf("flush text label canvas: %w", err)
+	}
+	texture.image = updateCanvasImage(canvas, nil)
+	r.textLabels[key] = texture
+	r.trimTextLabelTextures()
+	return texture, nil
+}
+
+func (r *runner) measureUITextLabelWidth(provider gpucontext.DeviceProvider, deviceScale float64, label UITextLabelCommand, size float32) (float32, error) {
+	canvas, err := ggcanvas.NewWithScale(provider, 1, 1, deviceScale)
+	if err != nil {
+		return 0, fmt.Errorf("create text label measure canvas: %w", err)
+	}
+	defer canvas.Close()
+	var width float32
+	if err := canvas.Draw(func(cc *gg.Context) {
+		uiCanvas := uirender.NewCanvas(cc, 1, 1)
+		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
+			textMode.SetTextMode(widget.TextModeVector)
+			defer textMode.SetTextMode(widget.TextModeAuto)
+		}
+		width = rotheme.MeasureText(uiCanvas, label.Text, size, label.Bold)
+	}); err != nil {
+		return 0, fmt.Errorf("measure text label: %w", err)
+	}
+	return width, nil
+}
+
+func drawOutlinedUIText(canvas widget.Canvas, label UITextLabelCommand, width, height int, size float32) {
+	fg := widget.RGBA8(label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A)
+	outline := widget.RGBA8(label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A)
+	bounds := geometry.NewRect(2, 2, float32(width-4), float32(height-4))
+	for _, offset := range [][2]float32{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
+		rotheme.DrawText(canvas, label.Text, bounds.TranslateXY(offset[0], offset[1]), size, outline, label.Bold, widget.TextAlignLeft)
+	}
+	rotheme.DrawText(canvas, label.Text, bounds, size, fg, label.Bold, widget.TextAlignLeft)
+}
+
+func uiTextLabelKey(label UITextLabelCommand) string {
+	return fmt.Sprintf("%s|%d|%d|%d|%d|%d|%d|%d|%d|%.1f|%t",
+		label.Text,
+		label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A,
+		label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A,
+		label.Size,
+		label.Bold,
+	)
+}
+
+func (r *runner) trimTextLabelTextures() {
+	if len(r.textLabels) <= 256 {
+		return
+	}
+	for key, texture := range r.textLabels {
+		if texture != nil && texture.canvas != nil {
+			_ = texture.canvas.Close()
+		}
+		delete(r.textLabels, key)
+		if len(r.textLabels) <= 192 {
+			return
+		}
+	}
+}
+
+func (r *runner) closeTextLabelTextures() {
+	for key, texture := range r.textLabels {
+		if texture != nil && texture.canvas != nil {
+			_ = texture.canvas.Close()
+		}
+		delete(r.textLabels, key)
+	}
 }
 
 func (r *runner) updateFPSCounter(now time.Time) {

--- a/render/backend.go
+++ b/render/backend.go
@@ -575,14 +575,14 @@ func (r *runner) draw(ctx *gogpu.Context) error {
 	r.screen.BeginFrame()
 	r.screen.SetScreenScale(scaleX, scaleY)
 	r.game.Draw(r.screen)
+	if err := r.drawUITextLabels(r.screen, deviceScale); err != nil {
+		return err
+	}
 	if err := r.drawUI(r.screen, width, height, deviceScale); err != nil {
 		return err
 	}
 	if drawer, ok := r.game.(overlayDrawer); ok {
 		drawer.DrawOverlay(r.screen)
-	}
-	if err := r.drawUITextLabels(r.screen, deviceScale); err != nil {
-		return err
 	}
 	if err := r.drawFPSMeter(r.screen, deviceScale); err != nil {
 		return err

--- a/render/backend.go
+++ b/render/backend.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"fmt"
+	"image/color"
 	"log"
 	"os"
 	"runtime/pprof"
@@ -77,6 +78,12 @@ type runtimeSettingsProvider interface {
 	RuntimeFPS() bool
 }
 
+type cachedOverlayImage struct {
+	image  *Image
+	width  int
+	height int
+}
+
 type runner struct {
 	app             *gogpu.App
 	ui              *uiapp.App
@@ -85,7 +92,8 @@ type runner struct {
 	fpsCanvas       *ggcanvas.Canvas
 	fpsImage        *Image
 	uiOverlayCanvas *ggcanvas.Canvas
-	uiOverlayImage  *Image
+	uiTextCache     map[string]cachedOverlayImage
+	uiBubbleCache   map[string]cachedOverlayImage
 	game            Game
 	screen          *Image
 	gpu             *gpuRenderer
@@ -713,7 +721,7 @@ func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
 }
 
 func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
-	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiTextLabels) == 0) {
+	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiSpeechBubbles) == 0 && len(screen.uiTextLabels) == 0) {
 		return nil
 	}
 	provider := r.app.GPUContextProvider()
@@ -723,91 +731,277 @@ func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
 	if deviceScale <= 0 {
 		deviceScale = 1
 	}
-	width, height := screen.Bounds().Dx(), screen.Bounds().Dy()
-	if width <= 0 || height <= 0 {
-		return nil
-	}
-	if r.uiOverlayCanvas == nil {
-		canvas, err := ggcanvas.NewWithScale(provider, width, height, deviceScale)
-		if err != nil {
-			return fmt.Errorf("create ui overlay canvas: %w", err)
-		}
-		r.uiOverlayCanvas = canvas
-		r.uiOverlayScale = deviceScale
-	}
-	canvasW, canvasH := r.uiOverlayCanvas.Size()
-	if canvasW != width || canvasH != height {
-		if err := r.uiOverlayCanvas.Resize(width, height); err != nil {
-			return fmt.Errorf("resize ui overlay canvas: %w", err)
-		}
-		r.uiOverlayImage = nil
-	}
 	if r.uiOverlayScale != deviceScale {
-		r.uiOverlayCanvas.SetDeviceScale(deviceScale)
 		r.uiOverlayScale = deviceScale
-		r.uiOverlayImage = nil
+		r.uiTextCache = nil
+		r.uiBubbleCache = nil
 	}
-	if err := r.uiOverlayCanvas.Draw(func(cc *gg.Context) {
+	for _, rect := range screen.uiRects {
+		DrawRect(screen, rect.X, rect.Y, rect.W, rect.H, rect.Color)
+	}
+	for _, bubble := range screen.uiSpeechBubbles {
+		cached, err := r.cachedSpeechBubbleImage(provider, bubble, deviceScale)
+		if err != nil {
+			return err
+		}
+		x := bubble.CenterX - float64(cached.width)/2
+		y := bubble.BottomY - float64(cached.height)
+		drawCachedOverlayImage(screen, cached, x, y)
+	}
+	for _, label := range screen.uiTextLabels {
+		cached, err := r.cachedTextLabelImage(provider, label, deviceScale)
+		if err != nil {
+			return err
+		}
+		x := label.X
+		if label.Centered {
+			x -= float64(cached.width) / 2
+		}
+		drawCachedOverlayImage(screen, cached, x, label.Y)
+	}
+	return nil
+}
+
+func drawCachedOverlayImage(screen *Image, cached cachedOverlayImage, x, y float64) {
+	if cached.image == nil || cached.width <= 0 || cached.height <= 0 {
+		return
+	}
+	x, y = snapScreenPoint(screen, x, y)
+	var opts DrawImageOptions
+	if b := cached.image.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
+		opts.GeoM.Scale(float64(cached.width)/float64(b.Dx()), float64(cached.height)/float64(b.Dy()))
+	}
+	opts.GeoM.Translate(x, y)
+	opts.Filter = FilterNearest
+	screen.DrawImage(cached.image, &opts)
+}
+
+func (r *runner) cachedTextLabelImage(provider gpucontext.DeviceProvider, label UITextLabelCommand, deviceScale float64) (cachedOverlayImage, error) {
+	size := label.Size
+	if size <= 0 {
+		size = rotheme.Default.Typography.TextSize
+	}
+	key := fmt.Sprintf("text|%.3f|%s|%t|%.1f|%08x|%08x", deviceScale, label.Text, label.Bold, size, rgbaKey(label.Foreground), rgbaKey(label.Outline))
+	if cached, ok := r.uiTextCache[key]; ok {
+		return cached, nil
+	}
+	measure, err := r.ensureOverlayCanvas(provider, 1, 1, deviceScale)
+	if err != nil {
+		return cachedOverlayImage{}, err
+	}
+	var textW float32
+	if err := measure.Draw(func(cc *gg.Context) {
+		canvas := uirender.NewCanvas(cc, 1, 1)
+		textW = rotheme.MeasureText(canvas, label.Text, size, label.Bold)
+	}); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("measure ui text overlay: %w", err)
+	}
+	width := int(textW + 4.999)
+	if width < 4 {
+		width = 4
+	}
+	height := int(size + 8)
+	if height < 16 {
+		height = 16
+	}
+	canvas, err := r.ensureOverlayCanvas(provider, width, height, deviceScale)
+	if err != nil {
+		return cachedOverlayImage{}, err
+	}
+	fg := widget.RGBA8(label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A)
+	outline := widget.RGBA8(label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A)
+	if err := canvas.Draw(func(cc *gg.Context) {
 		uiCanvas := uirender.NewCanvas(cc, width, height)
 		uiCanvas.Clear(widget.RGBA8(0, 0, 0, 0))
 		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
 			textMode.SetTextMode(widget.TextModeVector)
 			defer textMode.SetTextMode(widget.TextModeAuto)
 		}
-		for _, rect := range screen.uiRects {
-			uiCanvas.DrawRect(
-				geometry.NewRect(float32(rect.X), float32(rect.Y), float32(rect.W), float32(rect.H)),
-				widget.RGBA8(rect.Color.R, rect.Color.G, rect.Color.B, rect.Color.A),
-			)
+		bounds := geometry.NewRect(2, 2, float32(width), float32(height))
+		for _, offset := range [][2]float32{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
+			rotheme.DrawText(uiCanvas, label.Text, bounds.TranslateXY(offset[0], offset[1]), size, outline, label.Bold, widget.TextAlignLeft)
 		}
-		for _, label := range screen.uiTextLabels {
-			drawOutlinedUIText(uiCanvas, label)
-		}
+		rotheme.DrawText(uiCanvas, label.Text, bounds, size, fg, label.Bold, widget.TextAlignLeft)
 	}); err != nil {
-		return fmt.Errorf("draw ui overlay canvas: %w", err)
+		return cachedOverlayImage{}, fmt.Errorf("draw ui text overlay: %w", err)
 	}
-	if _, err := r.uiOverlayCanvas.Flush(); err != nil {
-		return fmt.Errorf("flush ui overlay canvas: %w", err)
+	if _, err := canvas.Flush(); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("flush ui text overlay: %w", err)
 	}
-	r.uiOverlayImage = updateCanvasImage(r.uiOverlayCanvas, r.uiOverlayImage)
-	if r.uiOverlayImage == nil {
-		return nil
+	cached := cachedOverlayImage{image: updateCanvasImage(canvas, nil), width: width, height: height}
+	if r.uiTextCache == nil {
+		r.uiTextCache = make(map[string]cachedOverlayImage)
 	}
-	var opts DrawImageOptions
-	if b := r.uiOverlayImage.Bounds(); b.Dx() > 0 && b.Dy() > 0 {
-		opts.GeoM.Scale(float64(width)/float64(b.Dx()), float64(height)/float64(b.Dy()))
-	}
-	opts.Filter = FilterNearest
-	screen.DrawImage(r.uiOverlayImage, &opts)
-	return nil
+	r.uiTextCache[key] = cached
+	return cached, nil
 }
 
-func drawOutlinedUIText(canvas widget.Canvas, label UITextLabelCommand) {
-	size := label.Size
-	if size <= 0 {
-		size = rotheme.Default.Typography.TextSize
+func (r *runner) cachedSpeechBubbleImage(provider gpucontext.DeviceProvider, bubble UISpeechBubbleCommand, deviceScale float64) (cachedOverlayImage, error) {
+	text := strings.TrimSpace(bubble.Text)
+	if text == "" {
+		return cachedOverlayImage{}, nil
 	}
-	textW := rotheme.MeasureText(canvas, label.Text, size, label.Bold)
-	x := float32(label.X)
-	if label.Centered {
-		x -= textW / 2
+	maxWidth := float32(bubble.MaxWidth)
+	if maxWidth <= 0 {
+		maxWidth = 220
 	}
-	y := float32(label.Y)
-	width := textW + 4
-	if width < 4 {
-		width = 4
+	const (
+		size     float32 = 11
+		lineH    float32 = 14
+		padX     float32 = 7
+		padY     float32 = 5
+		minWidth float32 = 28
+		maxLines         = 4
+	)
+	key := fmt.Sprintf("bubble|%.3f|%.1f|%s", deviceScale, maxWidth, text)
+	if cached, ok := r.uiBubbleCache[key]; ok {
+		return cached, nil
 	}
-	height := size + 8
-	if height < 16 {
-		height = 16
+	measure, err := r.ensureOverlayCanvas(provider, 1, 1, deviceScale)
+	if err != nil {
+		return cachedOverlayImage{}, err
 	}
-	fg := widget.RGBA8(label.Foreground.R, label.Foreground.G, label.Foreground.B, label.Foreground.A)
-	outline := widget.RGBA8(label.Outline.R, label.Outline.G, label.Outline.B, label.Outline.A)
-	bounds := geometry.NewRect(x+2, y+2, width, height)
-	for _, offset := range [][2]float32{{0, -1}, {0, 1}, {-1, 0}, {1, 0}} {
-		rotheme.DrawText(canvas, label.Text, bounds.TranslateXY(offset[0], offset[1]), size, outline, label.Bold, widget.TextAlignLeft)
+	var lines []string
+	if err := measure.Draw(func(cc *gg.Context) {
+		canvas := uirender.NewCanvas(cc, 1, 1)
+		lines = wrapOverlayText(canvas, text, size, false, maxWidth-padX*2)
+	}); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("measure speech bubble overlay: %w", err)
 	}
-	rotheme.DrawText(canvas, label.Text, bounds, size, fg, label.Bold, widget.TextAlignLeft)
+	if len(lines) > maxLines {
+		lines = append(lines[:maxLines-1], ellipsizeOverlayText(measure, strings.Join(lines[maxLines-1:], " "), size, false, maxWidth-padX*2))
+	}
+	textWidth := float32(0)
+	if err := measure.Draw(func(cc *gg.Context) {
+		canvas := uirender.NewCanvas(cc, 1, 1)
+		for _, line := range lines {
+			if w := rotheme.MeasureText(canvas, line, size, false); w > textWidth {
+				textWidth = w
+			}
+		}
+	}); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("measure speech bubble width: %w", err)
+	}
+	width := int(maxFloat32(minWidth, textWidth+padX*2) + 0.999)
+	if width > int(maxWidth) {
+		width = int(maxWidth)
+	}
+	height := int(float32(len(lines))*lineH + padY*2 + 0.999)
+	canvas, err := r.ensureOverlayCanvas(provider, width, height, deviceScale)
+	if err != nil {
+		return cachedOverlayImage{}, err
+	}
+	if err := canvas.Draw(func(cc *gg.Context) {
+		uiCanvas := uirender.NewCanvas(cc, width, height)
+		uiCanvas.Clear(widget.RGBA8(0, 0, 0, 0))
+		if textMode, ok := uiCanvas.(widget.TextModeController); ok {
+			textMode.SetTextMode(widget.TextModeVector)
+			defer textMode.SetTextMode(widget.TextModeAuto)
+		}
+		uiCanvas.DrawRect(geometry.NewRect(0, 0, float32(width), float32(height)), widget.RGBA8(0, 0, 0, 170))
+		fg := widget.RGBA8(255, 255, 255, 255)
+		for i, line := range lines {
+			y := padY + float32(i)*lineH
+			rotheme.DrawText(uiCanvas, line, geometry.NewRect(padX, y, float32(width)-padX*2, lineH), size, fg, false, widget.TextAlignLeft)
+		}
+	}); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("draw speech bubble overlay: %w", err)
+	}
+	if _, err := canvas.Flush(); err != nil {
+		return cachedOverlayImage{}, fmt.Errorf("flush speech bubble overlay: %w", err)
+	}
+	cached := cachedOverlayImage{image: updateCanvasImage(canvas, nil), width: width, height: height}
+	if r.uiBubbleCache == nil {
+		r.uiBubbleCache = make(map[string]cachedOverlayImage)
+	}
+	r.uiBubbleCache[key] = cached
+	return cached, nil
+}
+
+func (r *runner) ensureOverlayCanvas(provider gpucontext.DeviceProvider, width, height int, deviceScale float64) (*ggcanvas.Canvas, error) {
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+	if r.uiOverlayCanvas == nil {
+		canvas, err := ggcanvas.NewWithScale(provider, width, height, deviceScale)
+		if err != nil {
+			return nil, fmt.Errorf("create ui overlay canvas: %w", err)
+		}
+		r.uiOverlayCanvas = canvas
+		r.uiOverlayScale = deviceScale
+		return canvas, nil
+	}
+	canvasW, canvasH := r.uiOverlayCanvas.Size()
+	if canvasW != width || canvasH != height {
+		if err := r.uiOverlayCanvas.Resize(width, height); err != nil {
+			return nil, fmt.Errorf("resize ui overlay canvas: %w", err)
+		}
+	}
+	if r.uiOverlayScale != deviceScale {
+		r.uiOverlayCanvas.SetDeviceScale(deviceScale)
+		r.uiOverlayScale = deviceScale
+		r.uiTextCache = nil
+		r.uiBubbleCache = nil
+	}
+	return r.uiOverlayCanvas, nil
+}
+
+func wrapOverlayText(canvas widget.Canvas, text string, size float32, bold bool, maxWidth float32) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, 2)
+	line := ""
+	for _, word := range words {
+		candidate := word
+		if line != "" {
+			candidate = line + " " + word
+		}
+		if line == "" || rotheme.MeasureText(canvas, candidate, size, bold) <= maxWidth {
+			line = candidate
+			continue
+		}
+		lines = append(lines, line)
+		line = word
+	}
+	if line != "" {
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func ellipsizeOverlayText(canvas *ggcanvas.Canvas, text string, size float32, bold bool, maxWidth float32) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	result := text
+	_ = canvas.Draw(func(cc *gg.Context) {
+		uiCanvas := uirender.NewCanvas(cc, 1, 1)
+		if rotheme.MeasureText(uiCanvas, result, size, bold) <= maxWidth {
+			return
+		}
+		const suffix = "..."
+		runes := []rune(result)
+		for len(runes) > 0 {
+			candidate := strings.TrimSpace(string(runes)) + suffix
+			if rotheme.MeasureText(uiCanvas, candidate, size, bold) <= maxWidth {
+				result = candidate
+				return
+			}
+			runes = runes[:len(runes)-1]
+		}
+		result = suffix
+	})
+	return result
+}
+
+func rgbaKey(c color.RGBA) uint32 {
+	return uint32(c.R)<<24 | uint32(c.G)<<16 | uint32(c.B)<<8 | uint32(c.A)
 }
 
 func (r *runner) updateFPSCounter(now time.Time) {

--- a/render/backend.go
+++ b/render/backend.go
@@ -724,7 +724,7 @@ func updateCanvasImage(canvas *ggcanvas.Canvas, dstImage *Image) *Image {
 }
 
 func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
-	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiSpeechBubbles) == 0 && len(screen.uiTextLabels) == 0 && len(screen.uiTooltips) == 0) {
+	if screen == nil || (len(screen.uiRects) == 0 && len(screen.uiTextBoxes) == 0 && len(screen.uiTextLabels) == 0) {
 		return nil
 	}
 	defer screen.clearUIOverlayCommands()
@@ -743,13 +743,12 @@ func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
 	for _, rect := range screen.uiRects {
 		DrawRect(screen, rect.X, rect.Y, rect.W, rect.H, rect.Color)
 	}
-	for _, bubble := range screen.uiSpeechBubbles {
-		cached, err := r.cachedSpeechBubbleImage(provider, bubble, deviceScale)
+	for _, box := range screen.uiTextBoxes {
+		cached, err := r.cachedTextBoxImage(provider, box, deviceScale)
 		if err != nil {
 			return err
 		}
-		x := bubble.CenterX - float64(cached.width)/2
-		y := bubble.BottomY - float64(cached.height)
+		x, y := uiTextBoxPosition(screen, box, cached)
 		drawCachedOverlayImage(screen, cached, x, y)
 	}
 	for _, label := range screen.uiTextLabels {
@@ -763,22 +762,26 @@ func (r *runner) drawUIOverlay(screen *Image, deviceScale float64) error {
 		}
 		drawCachedOverlayImage(screen, cached, x, label.Y)
 	}
-	for _, tooltip := range screen.uiTooltips {
-		cached, err := r.cachedTooltipImage(provider, tooltip, deviceScale)
-		if err != nil {
-			return err
-		}
+	return nil
+}
+
+func uiTextBoxPosition(screen *Image, box UITextBoxCommand, cached cachedOverlayImage) (float64, float64) {
+	switch box.Anchor {
+	case UITextBoxAnchorBottomCenter:
+		return box.X - float64(cached.width)/2, box.Y - float64(cached.height)
+	case UITextBoxAnchorTooltipCenter:
 		screenW, screenH := screen.Bounds().Dx(), screen.Bounds().Dy()
-		x := tooltip.CenterX - float64(cached.width)/2
-		y := tooltip.BelowY
-		if y+float64(cached.height)+8 > float64(screenH) && tooltip.AboveY > 0 {
-			y = tooltip.AboveY - float64(cached.height)
+		x := box.X - float64(cached.width)/2
+		y := box.Y
+		if y+float64(cached.height)+8 > float64(screenH) && box.AltY > 0 {
+			y = box.AltY - float64(cached.height)
 		}
 		x = clampOverlayFloat64(x, 8, maxOverlayFloat64(8, float64(screenW-cached.width-8)))
 		y = clampOverlayFloat64(y, 8, maxOverlayFloat64(8, float64(screenH-cached.height-8)))
-		drawCachedOverlayImage(screen, cached, x, y)
+		return x, y
+	default:
+		return box.X, box.Y
 	}
-	return nil
 }
 
 func clampOverlayFloat64(v, lo, hi float64) float64 {
@@ -872,31 +875,28 @@ func (r *runner) cachedTextLabelImage(provider gpucontext.DeviceProvider, label 
 	return cached, nil
 }
 
-func (r *runner) cachedSpeechBubbleImage(provider gpucontext.DeviceProvider, bubble UISpeechBubbleCommand, deviceScale float64) (cachedOverlayImage, error) {
-	text := strings.TrimSpace(bubble.Text)
+func (r *runner) cachedTextBoxImage(provider gpucontext.DeviceProvider, box UITextBoxCommand, deviceScale float64) (cachedOverlayImage, error) {
+	text := strings.TrimSpace(box.Text)
 	if text == "" {
 		return cachedOverlayImage{}, nil
 	}
-	maxWidth := float32(bubble.MaxWidth)
+	maxWidth := float32(box.MaxWidth)
 	if maxWidth <= 0 {
-		maxWidth = 220
+		maxWidth = 0
 	}
-	key := fmt.Sprintf("bubble|%.3f|%.1f|%s", deviceScale, maxWidth, text)
+	maxLines := box.MaxLines
+	if maxLines <= 0 {
+		maxLines = 1
+	}
+	key := fmt.Sprintf("box|%.3f|%d|%.1f|%s", deviceScale, maxLines, maxWidth, text)
 	style := consoleOverlayTextBoxStyle()
-	style.minWidth = 28
-	style.maxWidth = maxWidth
-	style.maxLines = 4
-	style.wrap = true
-	return r.cachedOverlayTextBoxImage(provider, key, text, deviceScale, style)
-}
-
-func (r *runner) cachedTooltipImage(provider gpucontext.DeviceProvider, tooltip UITooltipCommand, deviceScale float64) (cachedOverlayImage, error) {
-	text := strings.TrimSpace(tooltip.Text)
-	if text == "" {
-		return cachedOverlayImage{}, nil
+	style.maxLines = maxLines
+	if maxWidth > 0 {
+		style.minWidth = 28
+		style.maxWidth = maxWidth
+		style.wrap = true
 	}
-	key := fmt.Sprintf("tooltip|%.3f|%s", deviceScale, text)
-	return r.cachedOverlayTextBoxImage(provider, key, text, deviceScale, consoleOverlayTextBoxStyle())
+	return r.cachedOverlayTextBoxImage(provider, key, text, deviceScale, style)
 }
 
 type overlayTextBoxStyle struct {
@@ -1116,10 +1116,17 @@ func (r *runner) drawFPSMeter(screen *Image, deviceScale float64) error {
 	if deviceScale <= 0 {
 		deviceScale = 1
 	}
-	cached, err := r.cachedOverlayTextBoxImage(provider, fmt.Sprintf("fps|%.3f|%s", deviceScale, r.fpsText), r.fpsText, deviceScale, consoleOverlayTextBoxStyle())
+	box := UITextBoxCommand{
+		Text:   r.fpsText,
+		X:      6,
+		Y:      6,
+		Anchor: UITextBoxAnchorTopLeft,
+	}
+	cached, err := r.cachedTextBoxImage(provider, box, deviceScale)
 	if err != nil {
 		return fmt.Errorf("draw fps overlay: %w", err)
 	}
-	drawCachedOverlayImage(screen, cached, 6, 6)
+	x, y := uiTextBoxPosition(screen, box, cached)
+	drawCachedOverlayImage(screen, cached, x, y)
 	return nil
 }

--- a/render/image.go
+++ b/render/image.go
@@ -190,6 +190,7 @@ type Image struct {
 	worldMeshes     []WorldMeshCommand
 	worldBillboards []WorldBillboardCommand
 	uiRects         []UIRectCommand
+	uiSpeechBubbles []UISpeechBubbleCommand
 	uiTextLabels    []UITextLabelCommand
 	clear           color.RGBA
 	camera          Camera3D
@@ -269,6 +270,13 @@ type UIRectCommand struct {
 	Color      color.RGBA
 }
 
+type UISpeechBubbleCommand struct {
+	Text     string
+	CenterX  float64
+	BottomY  float64
+	MaxWidth float64
+}
+
 func NewScreenImage(width, height int) *Image {
 	img := NewImage(width, height)
 	img.screen = true
@@ -286,6 +294,7 @@ func (i *Image) BeginFrame() {
 	i.worldMeshes = i.worldMeshes[:0]
 	i.worldBillboards = i.worldBillboards[:0]
 	i.uiRects = i.uiRects[:0]
+	i.uiSpeechBubbles = i.uiSpeechBubbles[:0]
 	i.uiTextLabels = i.uiTextLabels[:0]
 	i.camera = Camera3D{}
 }

--- a/render/image.go
+++ b/render/image.go
@@ -189,6 +189,7 @@ type Image struct {
 	worldCommands   []WorldCommand
 	worldMeshes     []WorldMeshCommand
 	worldBillboards []WorldBillboardCommand
+	uiTextLabels    []UITextLabelCommand
 	clear           color.RGBA
 	camera          Camera3D
 }
@@ -251,6 +252,17 @@ type WorldBillboardCommand struct {
 	DepthBias   float32
 }
 
+type UITextLabelCommand struct {
+	Text       string
+	X          float64
+	Y          float64
+	Foreground color.RGBA
+	Outline    color.RGBA
+	Centered   bool
+	Bold       bool
+	Size       float32
+}
+
 func NewScreenImage(width, height int) *Image {
 	img := NewImage(width, height)
 	img.screen = true
@@ -267,6 +279,7 @@ func (i *Image) BeginFrame() {
 	i.worldCommands = i.worldCommands[:0]
 	i.worldMeshes = i.worldMeshes[:0]
 	i.worldBillboards = i.worldBillboards[:0]
+	i.uiTextLabels = i.uiTextLabels[:0]
 	i.camera = Camera3D{}
 }
 

--- a/render/image.go
+++ b/render/image.go
@@ -192,6 +192,7 @@ type Image struct {
 	uiRects         []UIRectCommand
 	uiSpeechBubbles []UISpeechBubbleCommand
 	uiTextLabels    []UITextLabelCommand
+	uiTooltips      []UITooltipCommand
 	clear           color.RGBA
 	camera          Camera3D
 }
@@ -265,6 +266,13 @@ type UITextLabelCommand struct {
 	Size       float32
 }
 
+type UITooltipCommand struct {
+	Text    string
+	CenterX float64
+	BelowY  float64
+	AboveY  float64
+}
+
 type UIRectCommand struct {
 	X, Y, W, H float64
 	Color      color.RGBA
@@ -296,7 +304,18 @@ func (i *Image) BeginFrame() {
 	i.uiRects = i.uiRects[:0]
 	i.uiSpeechBubbles = i.uiSpeechBubbles[:0]
 	i.uiTextLabels = i.uiTextLabels[:0]
+	i.uiTooltips = i.uiTooltips[:0]
 	i.camera = Camera3D{}
+}
+
+func (i *Image) clearUIOverlayCommands() {
+	if i == nil {
+		return
+	}
+	i.uiRects = i.uiRects[:0]
+	i.uiSpeechBubbles = i.uiSpeechBubbles[:0]
+	i.uiTextLabels = i.uiTextLabels[:0]
+	i.uiTooltips = i.uiTooltips[:0]
 }
 
 func (i *Image) SetScreenScale(x, y float32) {

--- a/render/image.go
+++ b/render/image.go
@@ -190,9 +190,8 @@ type Image struct {
 	worldMeshes     []WorldMeshCommand
 	worldBillboards []WorldBillboardCommand
 	uiRects         []UIRectCommand
-	uiSpeechBubbles []UISpeechBubbleCommand
+	uiTextBoxes     []UITextBoxCommand
 	uiTextLabels    []UITextLabelCommand
-	uiTooltips      []UITooltipCommand
 	clear           color.RGBA
 	camera          Camera3D
 }
@@ -266,23 +265,27 @@ type UITextLabelCommand struct {
 	Size       float32
 }
 
-type UITooltipCommand struct {
-	Text    string
-	CenterX float64
-	BelowY  float64
-	AboveY  float64
-}
-
 type UIRectCommand struct {
 	X, Y, W, H float64
 	Color      color.RGBA
 }
 
-type UISpeechBubbleCommand struct {
+type UITextBoxAnchor int
+
+const (
+	UITextBoxAnchorTopLeft UITextBoxAnchor = iota
+	UITextBoxAnchorBottomCenter
+	UITextBoxAnchorTooltipCenter
+)
+
+type UITextBoxCommand struct {
 	Text     string
-	CenterX  float64
-	BottomY  float64
+	X        float64
+	Y        float64
+	AltY     float64
+	Anchor   UITextBoxAnchor
 	MaxWidth float64
+	MaxLines int
 }
 
 func NewScreenImage(width, height int) *Image {
@@ -302,9 +305,8 @@ func (i *Image) BeginFrame() {
 	i.worldMeshes = i.worldMeshes[:0]
 	i.worldBillboards = i.worldBillboards[:0]
 	i.uiRects = i.uiRects[:0]
-	i.uiSpeechBubbles = i.uiSpeechBubbles[:0]
+	i.uiTextBoxes = i.uiTextBoxes[:0]
 	i.uiTextLabels = i.uiTextLabels[:0]
-	i.uiTooltips = i.uiTooltips[:0]
 	i.camera = Camera3D{}
 }
 
@@ -313,9 +315,8 @@ func (i *Image) clearUIOverlayCommands() {
 		return
 	}
 	i.uiRects = i.uiRects[:0]
-	i.uiSpeechBubbles = i.uiSpeechBubbles[:0]
+	i.uiTextBoxes = i.uiTextBoxes[:0]
 	i.uiTextLabels = i.uiTextLabels[:0]
-	i.uiTooltips = i.uiTooltips[:0]
 }
 
 func (i *Image) SetScreenScale(x, y float32) {

--- a/render/image.go
+++ b/render/image.go
@@ -189,6 +189,7 @@ type Image struct {
 	worldCommands   []WorldCommand
 	worldMeshes     []WorldMeshCommand
 	worldBillboards []WorldBillboardCommand
+	uiRects         []UIRectCommand
 	uiTextLabels    []UITextLabelCommand
 	clear           color.RGBA
 	camera          Camera3D
@@ -263,6 +264,11 @@ type UITextLabelCommand struct {
 	Size       float32
 }
 
+type UIRectCommand struct {
+	X, Y, W, H float64
+	Color      color.RGBA
+}
+
 func NewScreenImage(width, height int) *Image {
 	img := NewImage(width, height)
 	img.screen = true
@@ -279,6 +285,7 @@ func (i *Image) BeginFrame() {
 	i.worldCommands = i.worldCommands[:0]
 	i.worldMeshes = i.worldMeshes[:0]
 	i.worldBillboards = i.worldBillboards[:0]
+	i.uiRects = i.uiRects[:0]
 	i.uiTextLabels = i.uiTextLabels[:0]
 	i.camera = Camera3D{}
 }

--- a/render/primitives.go
+++ b/render/primitives.go
@@ -306,11 +306,50 @@ func DrawOutlinedTextAt(dst *Image, text string, x, y int, foreground, outline c
 	if dst == nil || text == "" {
 		return
 	}
+	if dst.screen {
+		DrawUIOutlinedTextAt(dst, text, float64(x), float64(y), foreground, outline)
+		return
+	}
 	img := OutlinedTextImage(text, foreground, outline)
 	var opts DrawImageOptions
 	opts.GeoM.Translate(float64(x), float64(y))
 	opts.Filter = FilterNearest
 	dst.DrawImage(img, &opts)
+}
+
+func DrawUIOutlinedTextAt(dst *Image, text string, x, y float64, foreground, outline color.RGBA) {
+	queueUIOutlinedText(dst, text, x, y, foreground, outline, false)
+}
+
+func DrawCenteredUIOutlinedTextAt(dst *Image, text string, centerX, y float64, foreground, outline color.RGBA) {
+	queueUIOutlinedText(dst, text, centerX, y, foreground, outline, true)
+}
+
+func queueUIOutlinedText(dst *Image, text string, x, y float64, foreground, outline color.RGBA, centered bool) {
+	if dst == nil || text == "" {
+		return
+	}
+	if !dst.screen {
+		if centered {
+			img := OutlinedTextImage(text, foreground, outline)
+			if img == nil {
+				return
+			}
+			x -= float64(img.Bounds().Dx()) / 2
+		}
+		DrawOutlinedTextAt(dst, text, int(math.Round(x)), int(math.Round(y)), foreground, outline)
+		return
+	}
+	dst.uiTextLabels = append(dst.uiTextLabels, UITextLabelCommand{
+		Text:       text,
+		X:          x,
+		Y:          y,
+		Foreground: foreground,
+		Outline:    outline,
+		Centered:   centered,
+		Bold:       true,
+		Size:       12,
+	})
 }
 
 func drawTextWithFace(dst *Image, text string, x, y int, face font.Face, c color.RGBA) {

--- a/render/primitives.go
+++ b/render/primitives.go
@@ -144,6 +144,18 @@ func DrawUISpeechBubble(dst *Image, text string, centerX, bottomY, maxWidth floa
 	})
 }
 
+func DrawUITooltip(dst *Image, text string, centerX, belowY, aboveY float64) {
+	if dst == nil || text == "" || !dst.screen {
+		return
+	}
+	dst.uiTooltips = append(dst.uiTooltips, UITooltipCommand{
+		Text:    text,
+		CenterX: centerX,
+		BelowY:  belowY,
+		AboveY:  aboveY,
+	})
+}
+
 func DrawLine(dst *Image, x0, y0, x1, y1 float64, c color.Color) {
 	if dst == nil || dst.pix == nil {
 		return

--- a/render/primitives.go
+++ b/render/primitives.go
@@ -136,11 +136,13 @@ func DrawUISpeechBubble(dst *Image, text string, centerX, bottomY, maxWidth floa
 	if !dst.screen {
 		return
 	}
-	dst.uiSpeechBubbles = append(dst.uiSpeechBubbles, UISpeechBubbleCommand{
+	dst.uiTextBoxes = append(dst.uiTextBoxes, UITextBoxCommand{
 		Text:     text,
-		CenterX:  centerX,
-		BottomY:  bottomY,
+		X:        centerX,
+		Y:        bottomY,
+		Anchor:   UITextBoxAnchorBottomCenter,
 		MaxWidth: maxWidth,
+		MaxLines: 4,
 	})
 }
 
@@ -148,11 +150,12 @@ func DrawUITooltip(dst *Image, text string, centerX, belowY, aboveY float64) {
 	if dst == nil || text == "" || !dst.screen {
 		return
 	}
-	dst.uiTooltips = append(dst.uiTooltips, UITooltipCommand{
-		Text:    text,
-		CenterX: centerX,
-		BelowY:  belowY,
-		AboveY:  aboveY,
+	dst.uiTextBoxes = append(dst.uiTextBoxes, UITextBoxCommand{
+		Text:   text,
+		X:      centerX,
+		Y:      belowY,
+		AltY:   aboveY,
+		Anchor: UITextBoxAnchorTooltipCenter,
 	})
 }
 

--- a/render/primitives.go
+++ b/render/primitives.go
@@ -102,6 +102,23 @@ func DrawRect(dst *Image, x, y, w, h float64, c color.Color) {
 	}
 }
 
+func DrawUIRect(dst *Image, x, y, w, h float64, c color.RGBA) {
+	if dst == nil || w <= 0 || h <= 0 {
+		return
+	}
+	if !dst.screen {
+		DrawRect(dst, x, y, w, h, c)
+		return
+	}
+	dst.uiRects = append(dst.uiRects, UIRectCommand{
+		X:     x,
+		Y:     y,
+		W:     w,
+		H:     h,
+		Color: c,
+	})
+}
+
 func DrawLine(dst *Image, x0, y0, x1, y1 float64, c color.Color) {
 	if dst == nil || dst.pix == nil {
 		return

--- a/render/primitives.go
+++ b/render/primitives.go
@@ -88,6 +88,13 @@ func DrawRect(dst *Image, x, y, w, h float64, c color.Color) {
 	}
 	rgba := color.RGBAModel.Convert(c).(color.RGBA)
 	if dst.screen {
+		x0, y0 := snapScreenPoint(dst, x, y)
+		x1, y1 := snapScreenPoint(dst, x+w, y+h)
+		w, h = x1-x0, y1-y0
+		if w <= 0 || h <= 0 {
+			return
+		}
+		x, y = x0, y0
 		drawSolidQuad(dst, x, y, w, h, rgba)
 		return
 	}
@@ -116,6 +123,24 @@ func DrawUIRect(dst *Image, x, y, w, h float64, c color.RGBA) {
 		W:     w,
 		H:     h,
 		Color: c,
+	})
+}
+
+func DrawUISpeechBubble(dst *Image, text string, centerX, bottomY, maxWidth float64) {
+	if dst == nil || text == "" {
+		return
+	}
+	if maxWidth <= 0 {
+		maxWidth = 220
+	}
+	if !dst.screen {
+		return
+	}
+	dst.uiSpeechBubbles = append(dst.uiSpeechBubbles, UISpeechBubbleCommand{
+		Text:     text,
+		CenterX:  centerX,
+		BottomY:  bottomY,
+		MaxWidth: maxWidth,
 	})
 }
 
@@ -164,7 +189,8 @@ func DebugPrintAtColor(dst *Image, text string, x, y int, c color.RGBA) {
 	if dst.screen {
 		img := cachedDebugTextColor(text, c)
 		var opts DrawImageOptions
-		opts.GeoM.Translate(float64(x), float64(y))
+		x, y := snapScreenPoint(dst, float64(x), float64(y))
+		opts.GeoM.Translate(x, y)
 		opts.Filter = FilterNearest
 		dst.DrawImage(img, &opts)
 		return
@@ -323,10 +349,6 @@ func DrawOutlinedTextAt(dst *Image, text string, x, y int, foreground, outline c
 	if dst == nil || text == "" {
 		return
 	}
-	if dst.screen {
-		DrawUIOutlinedTextAt(dst, text, float64(x), float64(y), foreground, outline)
-		return
-	}
 	img := OutlinedTextImage(text, foreground, outline)
 	var opts DrawImageOptions
 	opts.GeoM.Translate(float64(x), float64(y))
@@ -335,38 +357,56 @@ func DrawOutlinedTextAt(dst *Image, text string, x, y int, foreground, outline c
 }
 
 func DrawUIOutlinedTextAt(dst *Image, text string, x, y float64, foreground, outline color.RGBA) {
-	queueUIOutlinedText(dst, text, x, y, foreground, outline, false)
+	drawOrQueueUIOutlinedText(dst, text, x, y, foreground, outline, false)
 }
 
 func DrawCenteredUIOutlinedTextAt(dst *Image, text string, centerX, y float64, foreground, outline color.RGBA) {
-	queueUIOutlinedText(dst, text, centerX, y, foreground, outline, true)
+	drawOrQueueUIOutlinedText(dst, text, centerX, y, foreground, outline, true)
 }
 
-func queueUIOutlinedText(dst *Image, text string, x, y float64, foreground, outline color.RGBA, centered bool) {
+func drawOrQueueUIOutlinedText(dst *Image, text string, x, y float64, foreground, outline color.RGBA, centered bool) {
 	if dst == nil || text == "" {
 		return
 	}
-	if !dst.screen {
-		if centered {
-			img := OutlinedTextImage(text, foreground, outline)
-			if img == nil {
-				return
-			}
-			x -= float64(img.Bounds().Dx()) / 2
-		}
-		DrawOutlinedTextAt(dst, text, int(math.Round(x)), int(math.Round(y)), foreground, outline)
+	if dst.screen {
+		dst.uiTextLabels = append(dst.uiTextLabels, UITextLabelCommand{
+			Text:       text,
+			X:          x,
+			Y:          y,
+			Foreground: foreground,
+			Outline:    outline,
+			Centered:   centered,
+			Bold:       true,
+			Size:       12,
+		})
 		return
 	}
-	dst.uiTextLabels = append(dst.uiTextLabels, UITextLabelCommand{
-		Text:       text,
-		X:          x,
-		Y:          y,
-		Foreground: foreground,
-		Outline:    outline,
-		Centered:   centered,
-		Bold:       true,
-		Size:       12,
-	})
+	img := OutlinedTextImage(text, foreground, outline)
+	if img == nil {
+		return
+	}
+	if centered {
+		x -= float64(img.Bounds().Dx()) / 2
+	}
+	x, y = snapScreenPoint(dst, x, y)
+	var opts DrawImageOptions
+	opts.GeoM.Translate(x, y)
+	opts.Filter = FilterNearest
+	dst.DrawImage(img, &opts)
+}
+
+func snapScreenPoint(dst *Image, x, y float64) (float64, float64) {
+	if dst == nil || !dst.screen {
+		return x, y
+	}
+	return snapScreenValue(x, float64(dst.screenScaleX)), snapScreenValue(y, float64(dst.screenScaleY))
+}
+
+func snapScreenValue(v, scale float64) float64 {
+	if scale <= 0 || math.IsNaN(scale) || math.IsInf(scale, 0) {
+		return math.Round(v)
+	}
+	return math.Round(v*scale) / scale
 }
 
 func drawTextWithFace(dst *Image, text string, x, y int, face font.Face, c color.RGBA) {

--- a/ui/equipment_window.go
+++ b/ui/equipment_window.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogpu/ui/primitives"
 	"github.com/gogpu/ui/widget"
 	"github.com/kivutar/goro/db"
+	"github.com/kivutar/goro/render"
 	"github.com/kivutar/goro/res"
 	"github.com/kivutar/goro/session"
 	"github.com/kivutar/goro/ui/rotheme"
@@ -30,13 +31,15 @@ const (
 
 type EquipmentWindow struct {
 	Window
-	snapshot string
-	itemInfo *ItemInfoWindow
-	cart     *CartWindow
-	hasCart  bool
-	preview  image.Image
-	icons    map[equipmentItemIconKey]image.Image
-	iconMiss map[equipmentItemIconKey]struct{}
+	snapshot    string
+	itemInfo    *ItemInfoWindow
+	cart        *CartWindow
+	hasCart     bool
+	preview     image.Image
+	tooltipItem session.InventoryItem
+	tooltipOpen bool
+	icons       map[equipmentItemIconKey]image.Image
+	iconMiss    map[equipmentItemIconKey]struct{}
 }
 
 type equipmentItemIconKey struct {
@@ -90,6 +93,7 @@ var (
 func (w *EquipmentWindow) Toggle(ctx Context) {
 	w.EnsureWindow(equipmentWindowWidth, equipmentWindowHeight)
 	if w.IsOpen() {
+		w.hideTooltip()
 		w.Window.Close()
 		w.Publish(ctx)
 		return
@@ -104,12 +108,14 @@ func (w *EquipmentWindow) Toggle(ctx Context) {
 func (w *EquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow, cart *CartWindow, assets AssetProvider) bool {
 	w.EnsureWindow(equipmentWindowWidth, equipmentWindowHeight)
 	if !w.IsOpen() {
+		w.hideTooltip()
 		return false
 	}
 	snapshot := equipmentSnapshot(ctx.Session)
 	needsPreview := w.preview == nil && assets != nil
 	hasCart := inventoryBagHasCart(ctx)
 	if snapshot != w.snapshot || itemInfo != w.itemInfo || cart != w.cart || hasCart != w.hasCart || needsPreview {
+		w.hideTooltip()
 		w.snapshot = snapshot
 		w.itemInfo = itemInfo
 		w.cart = cart
@@ -121,6 +127,7 @@ func (w *EquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow, cart *Ca
 	}
 	consumed := w.Window.Update(ctx)
 	if !w.IsOpen() {
+		w.hideTooltip()
 		w.Publish(ctx)
 		return consumed
 	}
@@ -247,9 +254,13 @@ func (w *EquipmentWindow) slotWidget(ctx Context, itemInfo *ItemInfoWindow, slot
 		width:   width,
 		res:     ctx.Resources,
 		onClick: func(item session.InventoryItem) {
+			w.hideTooltip()
 			w.activateItem(ctx, item)
 		},
+		onHover: func(item session.InventoryItem) { w.showTooltip(item) },
+		onLeave: func() { w.hideTooltip() },
 		onRightClick: func(item session.InventoryItem) {
+			w.hideTooltip()
 			if itemInfo != nil {
 				x, y := 0, 0
 				if ctx.Input != nil {
@@ -259,6 +270,27 @@ func (w *EquipmentWindow) slotWidget(ctx Context, itemInfo *ItemInfoWindow, slot
 			}
 		},
 	})
+}
+
+func (w *EquipmentWindow) DrawTooltip(screen *render.Image, ctx Context) {
+	if !w.tooltipOpen || screen == nil || ctx.Input == nil {
+		return
+	}
+	drawInventoryItemTooltip(screen, ctx, w.tooltipItem)
+}
+
+func (w *EquipmentWindow) showTooltip(item session.InventoryItem) {
+	if item.ItemID == 0 {
+		w.hideTooltip()
+		return
+	}
+	w.tooltipItem = item
+	w.tooltipOpen = true
+}
+
+func (w *EquipmentWindow) hideTooltip() {
+	w.tooltipItem = session.InventoryItem{}
+	w.tooltipOpen = false
 }
 
 func (w *EquipmentWindow) itemIconImage(manager *res.Manager, item session.InventoryItem) image.Image {
@@ -366,6 +398,8 @@ type equipmentSlotWidgetConfig struct {
 	width        int
 	res          *res.Manager
 	onClick      func(session.InventoryItem)
+	onHover      func(session.InventoryItem)
+	onLeave      func()
 	onRightClick func(session.InventoryItem)
 }
 
@@ -454,14 +488,22 @@ func (w *equipmentSlotWidget) Event(ctx widget.Context, e event.Event) bool {
 		return false
 	}
 	switch mouse.MouseType {
-	case event.MouseEnter:
+	case event.MouseEnter, event.MouseMove:
 		w.hovered = true
 		if w.cfg.hasItem {
+			if w.cfg.onHover != nil {
+				w.cfg.onHover(w.cfg.item)
+			}
 			ctx.SetCursor(widget.CursorPointer)
+		} else if w.cfg.onLeave != nil {
+			w.cfg.onLeave()
 		}
 		return w.cfg.hasItem
 	case event.MouseLeave:
 		w.hovered = false
+		if w.cfg.onLeave != nil {
+			w.cfg.onLeave()
+		}
 		ctx.SetCursor(widget.CursorDefault)
 		return false
 	case event.MousePress:

--- a/ui/equipment_window_test.go
+++ b/ui/equipment_window_test.go
@@ -62,3 +62,21 @@ func TestEquipmentWindowOpensCentered(t *testing.T) {
 		t.Fatalf("equipment position = %d,%d, want centered", window.Window.x, window.Window.y)
 	}
 }
+
+func TestEquipmentWindowTooltipTracksHoveredItem(t *testing.T) {
+	window := EquipmentWindow{}
+	item := session.InventoryItem{Index: 3, ItemID: 1201, Identified: true}
+
+	window.showTooltip(item)
+	if !window.tooltipOpen {
+		t.Fatal("tooltip should be open")
+	}
+	if window.tooltipItem.ItemID != item.ItemID || window.tooltipItem.Index != item.Index {
+		t.Fatalf("tooltip item = %+v, want %+v", window.tooltipItem, item)
+	}
+
+	window.hideTooltip()
+	if window.tooltipOpen || window.tooltipItem.ItemID != 0 {
+		t.Fatalf("tooltip not cleared: open=%t item=%+v", window.tooltipOpen, window.tooltipItem)
+	}
+}

--- a/ui/inventory_bag_window.go
+++ b/ui/inventory_bag_window.go
@@ -60,6 +60,8 @@ type InventoryBagWindow struct {
 	dragItem      session.InventoryItem
 	dragActive    bool
 	dragFrom      time.Time
+	tooltipItem   session.InventoryItem
+	tooltipOpen   bool
 	icons         map[inventoryBagIconKey]image.Image
 	iconMiss      map[inventoryBagIconKey]struct{}
 }
@@ -72,6 +74,7 @@ type inventoryBagIconKey struct {
 func (w *InventoryBagWindow) Toggle(ctx Context) {
 	w.EnsureWindow(inventoryBagWidth, inventoryBagHeight)
 	if w.IsOpen() {
+		w.hideTooltip()
 		w.Window.Close()
 		w.Publish(ctx)
 		return
@@ -87,6 +90,7 @@ func (w *InventoryBagWindow) Toggle(ctx Context) {
 func (w *InventoryBagWindow) Update(ctx Context, shortcuts *ShortcutBar, storage *StorageWindow, cart *CartWindow, trade *TradeWindow, itemInfo *ItemInfoWindow) bool {
 	w.EnsureWindow(inventoryBagWidth, inventoryBagHeight)
 	if !w.IsOpen() || ctx.Input == nil {
+		w.hideTooltip()
 		return false
 	}
 	cartChanged := cart != w.cart
@@ -103,6 +107,7 @@ func (w *InventoryBagWindow) Update(ctx Context, shortcuts *ShortcutBar, storage
 	}
 	consumed := w.Window.Update(ctx)
 	if !w.IsOpen() {
+		w.hideTooltip()
 		w.Publish(ctx)
 		return consumed
 	}
@@ -147,6 +152,13 @@ func (w *InventoryBagWindow) Draw(screen *render.Image, ctx Context, assets Asse
 	w.Publish(ctx)
 }
 
+func (w *InventoryBagWindow) DrawTooltip(screen *render.Image, ctx Context) {
+	if !w.tooltipOpen || w.dragActive || screen == nil || ctx.Input == nil {
+		return
+	}
+	drawInventoryItemTooltip(screen, ctx, w.tooltipItem)
+}
+
 func (w *InventoryBagWindow) DrawDragGhost(screen *render.Image, ctx Context, assets AssetProvider) {
 	if !w.dragActive || screen == nil || ctx.Input == nil || assets == nil {
 		return
@@ -185,7 +197,10 @@ func (w *InventoryBagWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow, c
 					scroll:  w.scroll,
 					onWheel: func(delta float32) { w.scrollBy(delta, ctx.Session); w.refresh(ctx, itemInfo) },
 					onPress: func(item session.InventoryItem) { w.startItemDragOrActivate(ctx, item) },
+					onHover: func(item session.InventoryItem) { w.showTooltip(item) },
+					onLeave: func() { w.hideTooltip() },
 					onRightClick: func(item session.InventoryItem, mx, my int) {
+						w.hideTooltip()
 						w.dragActive = false
 						w.dragItem = session.InventoryItem{}
 						if itemInfo != nil {
@@ -211,6 +226,7 @@ func (w *InventoryBagWindow) tabColumn(ctx Context, cart *CartWindow) widget.Wid
 			blendEdge:  tabBlendRight,
 			blendInset: inventoryBagTabOver,
 			onClick: func() {
+				w.hideTooltip()
 				w.tab = tab.tab
 				w.scroll = 0
 				w.lastClickItem = 0
@@ -237,6 +253,7 @@ func (w *InventoryBagWindow) tabColumn(ctx Context, cart *CartWindow) widget.Wid
 }
 
 func (w *InventoryBagWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
+	w.hideTooltip()
 	w.ClampScroll(ctx.Session)
 	w.snapshot = w.inventorySnapshot(ctx.Session)
 	w.itemInfo = itemInfo
@@ -255,6 +272,7 @@ func inventoryBagHasCart(ctx Context) bool {
 }
 
 func (w *InventoryBagWindow) startItemDragOrActivate(ctx Context, item session.InventoryItem) {
+	w.hideTooltip()
 	now := time.Now()
 	if w.lastClickItem == item.Index && now.Sub(w.lastClickAt) <= 360*time.Millisecond {
 		w.dragActive = false
@@ -269,6 +287,20 @@ func (w *InventoryBagWindow) startItemDragOrActivate(ctx Context, item session.I
 	w.dragFrom = now
 	w.lastClickItem = item.Index
 	w.lastClickAt = now
+}
+
+func (w *InventoryBagWindow) showTooltip(item session.InventoryItem) {
+	if item.ItemID == 0 {
+		w.hideTooltip()
+		return
+	}
+	w.tooltipItem = item
+	w.tooltipOpen = true
+}
+
+func (w *InventoryBagWindow) hideTooltip() {
+	w.tooltipItem = session.InventoryItem{}
+	w.tooltipOpen = false
 }
 
 func (w *InventoryBagWindow) pointInside(x, y int) bool {
@@ -527,6 +559,8 @@ type inventoryGridConfig struct {
 	scroll       int
 	onWheel      func(float32)
 	onPress      func(session.InventoryItem)
+	onHover      func(session.InventoryItem)
+	onLeave      func()
 	onRightClick func(session.InventoryItem, int, int)
 }
 
@@ -596,13 +630,22 @@ func (w *inventoryGridWidget) Event(ctx widget.Context, e event.Event) bool {
 		case event.MouseEnter, event.MouseMove:
 			w.hovered = index
 			if index >= 0 && index < len(w.cfg.items) {
+				if w.cfg.onHover != nil {
+					w.cfg.onHover(w.cfg.items[index])
+				}
 				ctx.SetCursor(widget.CursorPointer)
 			} else {
+				if w.cfg.onLeave != nil {
+					w.cfg.onLeave()
+				}
 				ctx.SetCursor(widget.CursorDefault)
 			}
 			return true
 		case event.MouseLeave:
 			w.hovered = -1
+			if w.cfg.onLeave != nil {
+				w.cfg.onLeave()
+			}
 			ctx.SetCursor(widget.CursorDefault)
 			return false
 		case event.MousePress:

--- a/ui/inventory_common.go
+++ b/ui/inventory_common.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kivutar/goro/render"
 	"github.com/kivutar/goro/res"
 	"github.com/kivutar/goro/session"
 )
@@ -39,6 +40,17 @@ func inventoryItemDisplayName(manager *res.Manager, item session.InventoryItem) 
 		}
 	}
 	return fmt.Sprintf("item %d", item.ItemID)
+}
+
+func drawInventoryItemTooltip(screen *render.Image, ctx Context, item session.InventoryItem) {
+	if screen == nil || ctx.Input == nil {
+		return
+	}
+	text := inventoryItemDisplayName(ctx.Resources, item)
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	render.DrawUITooltip(screen, text, float64(ctx.Input.MouseX), float64(ctx.Input.MouseY+18), float64(ctx.Input.MouseY-6))
 }
 
 func inventoryItemDisplayNameWithSlots(manager *res.Manager, item session.InventoryItem, name string) string {

--- a/ui/shop_inventory_storage_test.go
+++ b/ui/shop_inventory_storage_test.go
@@ -161,6 +161,24 @@ func TestInventoryBagShowsCartButtonOnlyWhenPlayerHasCart(t *testing.T) {
 	}
 }
 
+func TestInventoryBagTooltipTracksHoveredItem(t *testing.T) {
+	window := InventoryBagWindow{}
+	item := session.InventoryItem{Index: 8, ItemID: 501, Identified: true}
+
+	window.showTooltip(item)
+	if !window.tooltipOpen {
+		t.Fatal("tooltip should be open")
+	}
+	if window.tooltipItem.ItemID != item.ItemID || window.tooltipItem.Index != item.Index {
+		t.Fatalf("tooltip item = %+v, want %+v", window.tooltipItem, item)
+	}
+
+	window.hideTooltip()
+	if window.tooltipOpen || window.tooltipItem.ItemID != 0 {
+		t.Fatalf("tooltip not cleared: open=%t item=%+v", window.tooltipOpen, window.tooltipItem)
+	}
+}
+
 func TestStorageDragReleaseOverInventoryWithdraws(t *testing.T) {
 	inputState := input.NewState()
 	inputState.SetMousePosition(40, 40)

--- a/ui/shortcut_bar.go
+++ b/ui/shortcut_bar.go
@@ -46,18 +46,20 @@ type shortcutSlotState struct {
 }
 
 type ShortcutBar struct {
-	slots     [shortcutSlots]shortcutSlotState
-	loaded    bool
-	path      string
-	content   widget.Widget
-	root      widget.Widget
-	published bool
-	rootX     int
-	ctx       Context
-	actions   GameActions
-	assets    AssetProvider
-	icons     map[shortcutItemIconKey]image.Image
-	iconMiss  map[shortcutItemIconKey]struct{}
+	slots       [shortcutSlots]shortcutSlotState
+	loaded      bool
+	path        string
+	content     widget.Widget
+	root        widget.Widget
+	published   bool
+	rootX       int
+	ctx         Context
+	actions     GameActions
+	assets      AssetProvider
+	icons       map[shortcutItemIconKey]image.Image
+	iconMiss    map[shortcutItemIconKey]struct{}
+	tooltipSlot int
+	tooltipOpen bool
 }
 
 type shortcutItemIconKey struct {
@@ -124,9 +126,28 @@ func (b *ShortcutBar) ResetOverlay(ctx Context) {
 	if b.published && ctx.UIManager != nil && b.root != nil {
 		ctx.UIManager.RemoveOverlay(b.root)
 	}
+	b.hideTooltip()
 	b.published = false
 	b.root = nil
 	b.content = nil
+}
+
+func (b *ShortcutBar) DrawTooltip(screen *render.Image, ctx Context) {
+	if !b.tooltipOpen {
+		return
+	}
+	text := b.tooltipText(b.tooltipSlot)
+	if text == "" {
+		return
+	}
+	barX, barY := b.bounds(ctx)
+	render.DrawUITooltip(
+		screen,
+		text,
+		float64(barX+shortcutBarWidth()/2),
+		float64(barY+shortcutBarHeight()+2),
+		float64(barY-2),
+	)
 }
 
 func (b *ShortcutBar) AcceptItemDrop(ctx Context, item session.InventoryItem, mx, my int) bool {
@@ -392,10 +413,12 @@ func (w *shortcutSlotButton) Event(ctx widget.Context, e event.Event) bool {
 	case event.MouseEnter, event.MouseMove:
 		w.hovered = true
 		ctx.SetCursor(widget.CursorPointer)
+		w.bar.showTooltip(w.slot)
 		return true
 	case event.MouseLeave:
 		w.hovered = false
 		ctx.SetCursor(widget.CursorDefault)
+		w.bar.hideTooltip()
 	case event.MousePress:
 		switch mouse.Button {
 		case event.ButtonLeft:
@@ -404,11 +427,53 @@ func (w *shortcutSlotButton) Event(ctx widget.Context, e event.Event) bool {
 		case event.ButtonRight:
 			w.bar.slots[w.slot] = shortcutSlotState{}
 			w.bar.save(w.bar.ctx)
+			w.bar.hideTooltip()
 			w.bar.redraw()
 			return true
 		}
 	}
 	return true
+}
+
+func (b *ShortcutBar) showTooltip(slot int) {
+	if slot < 0 || slot >= shortcutSlots {
+		return
+	}
+	if b.tooltipText(slot) == "" {
+		b.hideTooltip()
+		return
+	}
+	if b.tooltipOpen && b.tooltipSlot == slot {
+		return
+	}
+	b.tooltipSlot = slot
+	b.tooltipOpen = true
+}
+
+func (b *ShortcutBar) tooltipText(slot int) string {
+	if slot < 0 || slot >= shortcutSlots {
+		return ""
+	}
+	entry := b.slots[slot]
+	if entry.kind != shortcutSkill {
+		return ""
+	}
+	skill, ok := skillForShortcut(b.ctx.Session, entry)
+	if !ok {
+		skill = session.Skill{ID: entry.skillID, Level: entry.skillLevel}
+	}
+	if skill.ID == 0 {
+		return ""
+	}
+	name := trimRunes(skillDisplayName(b.ctx.Resources, skill), 38)
+	if name == "" {
+		return ""
+	}
+	return fmt.Sprintf("[ F%d ] %s", slot+1, name)
+}
+
+func (b *ShortcutBar) hideTooltip() {
+	b.tooltipOpen = false
 }
 
 func (b *ShortcutBar) redraw() {

--- a/ui/shortcut_bar_test.go
+++ b/ui/shortcut_bar_test.go
@@ -182,3 +182,48 @@ func TestSkillForShortcutFallsBackAndClampsLevel(t *testing.T) {
 		t.Fatalf("clamped shortcut level = %d, want learned level 4", skill.Level)
 	}
 }
+
+func TestShortcutSkillTooltipUsesHotkeyAndName(t *testing.T) {
+	bar := &ShortcutBar{}
+	bar.slots[1] = shortcutSlotState{kind: shortcutSkill, skillID: 6, skillLevel: 2}
+	bar.ctx = Context{
+		ScreenW: 800,
+		ScreenH: 600,
+		Session: &session.Session{
+			Skills: session.Skills{
+				List: []session.Skill{{ID: 6, Level: 8, Name: "Provoke"}},
+			},
+		},
+	}
+
+	bar.showTooltip(1)
+	if !bar.tooltipOpen || bar.tooltipSlot != 1 {
+		t.Fatalf("tooltip state open=%v slot=%d, want slot 1 open", bar.tooltipOpen, bar.tooltipSlot)
+	}
+	if got := bar.tooltipText(1); got != "[ F2 ] Provoke" {
+		t.Fatalf("tooltip text = %q", got)
+	}
+}
+
+func TestShortcutTooltipUnpublishesForEmptySlot(t *testing.T) {
+	bar := &ShortcutBar{}
+	bar.slots[0] = shortcutSlotState{kind: shortcutSkill, skillID: 6, skillLevel: 2}
+	bar.ctx = Context{
+		ScreenW: 800,
+		ScreenH: 600,
+		Session: &session.Session{
+			Skills: session.Skills{
+				List: []session.Skill{{ID: 6, Level: 2, Name: "Provoke"}},
+			},
+		},
+	}
+
+	bar.showTooltip(0)
+	if !bar.tooltipOpen {
+		t.Fatal("tooltip did not open")
+	}
+	bar.showTooltip(1)
+	if bar.tooltipOpen {
+		t.Fatal("tooltip is still open after hovering empty slot")
+	}
+}


### PR DESCRIPTION
## Goal
This PR is about making small in-game text overlays look good and behave consistently. The immediate targets are the FPS meter, actor names/life bars, speech bubbles, and shortcut tooltips.

The goal is not only to add the missing tooltip feature. It is to move these overlays onto one high-quality cached gogpu/ui text rendering path, so we stop mixing sharp UI text with older debug text rendering.

## Design Priorities
- Text quality: use the same vector text rendering path as gogpu/ui instead of the old debug font path.
- Shared code: FPS meter, speech bubbles, and tooltips now use one cached overlay text-box command/path instead of separate custom renderers.
- Unified appearance: these overlay boxes share the same console-style background color, alpha, font size, text color, line height, and padding.
- Low boilerplate: callers enqueue simple overlay commands; placement differences are handled by anchor modes rather than separate widget/render implementations.
- Performance: overlay text is rendered into small cached textures keyed by content/style/scale, then blitted. We avoid full-screen overlay rasterization and avoid live text layout every frame.

## Summary
- render FPS meter, actor names, speech bubbles, and shortcut tooltips through cached UI text overlays
- add shortcut skill hover tooltips using RO-style hotkey/name text
- unify FPS, speech bubble, and tooltip rendering through one cached text-box path
- keep actor name/life overlays below normal UI windows, while drawing shortcut tooltips above UI and below the RO cursor

## Tests
- go test ./...
- staticcheck ./...
- CGO_ENABLED=0 go build -tags nofakecgo ./...