### PR TITLE
Add --no-audio option for profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Useful options:
 --fullscreen
 --bgm=false
 --bgm-volume 0.35
+--no-audio # disable BGM and SFX output entirely (useful for profiling)
 --graphics-api gles # fallback if Vulkan is unavailable
 --vsync=false # unlock fps
 --username <username> # prefill the username in login window

--- a/app/app.go
+++ b/app/app.go
@@ -52,7 +52,7 @@ func New(cfg config.Config) (*Game, error) {
 		session:  session.New(),
 		world:    world.New(),
 		network:  network.NewClient(cfg.Packet.ClientDate, cfg.Network.Trace),
-		audio:    gameaudio.NewBGM(resource, cfg.Audio.BGM, cfg.Audio.BGMVolume, cfg.Audio.SFXVolume),
+		audio:    gameaudio.NewBGM(resource, cfg.Audio.BGM, cfg.Audio.BGMVolume, cfg.Audio.SFXVolume, cfg.Audio.Disabled),
 		runtime:  newRuntimeSettings(cfg.Window.Fullscreen, cfg.Render.VSync, cfg.Render.FPS),
 		ui:       gameui.NewManager(),
 		started:  time.Now(),

--- a/audio/bgm.go
+++ b/audio/bgm.go
@@ -36,14 +36,16 @@ type BGM struct {
 	bgmVolume  float64
 	sfxVolume  float64
 	sfxPlayers []*oto.Player
+	disabled   bool
 }
 
-func NewBGM(resources *res.Manager, enabled bool, bgmVolume, sfxVolume float64) *BGM {
+func NewBGM(resources *res.Manager, enabled bool, bgmVolume, sfxVolume float64, disabled bool) *BGM {
 	return &BGM{
 		resources: resources,
-		enabled:   enabled,
+		enabled:   enabled && !disabled,
 		bgmVolume: clampVolume(bgmVolume),
 		sfxVolume: clampVolume(sfxVolume),
+		disabled:  disabled,
 	}
 }
 
@@ -55,7 +57,7 @@ func (b *BGM) Enabled() bool {
 }
 
 func (b *BGM) SetEnabled(enabled bool) {
-	if b == nil || b.enabled == enabled {
+	if b == nil || b.disabled || b.enabled == enabled {
 		return
 	}
 	b.enabled = enabled
@@ -183,7 +185,7 @@ func (b *BGM) PlaySFX(path string) (string, error) {
 }
 
 func (b *BGM) PlaySFXVolume(path string, volume float64) (string, error) {
-	if b == nil {
+	if b == nil || b.disabled || b.sfxVolume <= 0 || volume <= 0 {
 		return "", nil
 	}
 	path = normalizeSFXPath(path)

--- a/audio/bgm_stub.go
+++ b/audio/bgm_stub.go
@@ -7,12 +7,14 @@ import "github.com/kivutar/goro/res"
 type BGM struct {
 	bgmVolume float64
 	sfxVolume float64
+	disabled  bool
 }
 
-func NewBGM(_ *res.Manager, _ bool, bgmVolume, sfxVolume float64) *BGM {
+func NewBGM(_ *res.Manager, _ bool, bgmVolume, sfxVolume float64, disabled bool) *BGM {
 	return &BGM{
 		bgmVolume: clampVolume(bgmVolume),
 		sfxVolume: clampVolume(sfxVolume),
+		disabled:  disabled,
 	}
 }
 

--- a/audio/volume_test.go
+++ b/audio/volume_test.go
@@ -5,7 +5,7 @@ package audio
 import "testing"
 
 func TestBGMAndSFXVolumesAreSeparate(t *testing.T) {
-	bgm := NewBGM(nil, true, 0.25, 0.75)
+	bgm := NewBGM(nil, true, 0.25, 0.75, false)
 	if bgm.BGMVolume() != 0.25 {
 		t.Fatalf("bgm volume = %v, want 0.25", bgm.BGMVolume())
 	}
@@ -24,11 +24,40 @@ func TestBGMAndSFXVolumesAreSeparate(t *testing.T) {
 }
 
 func TestAudioVolumesClamp(t *testing.T) {
-	bgm := NewBGM(nil, true, -1, 2)
+	bgm := NewBGM(nil, true, -1, 2, false)
 	if bgm.BGMVolume() != 0 {
 		t.Fatalf("bgm volume = %v, want 0", bgm.BGMVolume())
 	}
 	if bgm.SFXVolume() != 1 {
 		t.Fatalf("sfx volume = %v, want 1", bgm.SFXVolume())
+	}
+}
+
+func TestMutedSFXDoesNotInitializeAudio(t *testing.T) {
+	bgm := NewBGM(nil, false, 0, 0, false)
+	path, err := bgm.PlaySFXVolume("missing.wav", 1)
+	if err != nil {
+		t.Fatalf("muted SFX returned error: %v", err)
+	}
+	if path != "" {
+		t.Fatalf("muted SFX path = %q, want empty", path)
+	}
+}
+
+func TestDisabledAudioCannotBeReenabled(t *testing.T) {
+	bgm := NewBGM(nil, true, 0.5, 0.5, true)
+	if bgm.Enabled() {
+		t.Fatal("disabled audio reported BGM enabled")
+	}
+	bgm.SetEnabled(true)
+	if bgm.Enabled() {
+		t.Fatal("disabled audio was reenabled")
+	}
+	path, err := bgm.PlaySFXVolume("missing.wav", 1)
+	if err != nil {
+		t.Fatalf("disabled SFX returned error: %v", err)
+	}
+	if path != "" {
+		t.Fatalf("disabled SFX path = %q, want empty", path)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type LoginConfig struct {
 }
 
 type AudioConfig struct {
+	Disabled  bool
 	BGM       bool
 	BGMVolume float64
 	SFXVolume float64
@@ -294,6 +295,7 @@ func applyCLI(cfg *Config, args []string) error {
 	fs.BoolVar(&cfg.Login.AutoLogin, "autologin", cfg.Login.AutoLogin, "attempt login automatically")
 	fs.IntVar(&cfg.Login.CharSlot, "char-slot", cfg.Login.CharSlot, "character slot to select after autologin, 0 to 8")
 	fs.BoolVar(&cfg.Audio.BGM, "bgm", cfg.Audio.BGM, "enable BGM")
+	fs.BoolVar(&cfg.Audio.Disabled, "no-audio", cfg.Audio.Disabled, "disable all audio output")
 	fs.Float64Var(&cfg.Audio.BGMVolume, "bgm-volume", cfg.Audio.BGMVolume, "BGM volume from 0 to 1")
 	fs.Float64Var(&cfg.Audio.SFXVolume, "sfx-volume", cfg.Audio.SFXVolume, "SFX volume from 0 to 1")
 	fs.StringVar(&cfg.Render.GraphicsAPI, "graphics-api", cfg.Render.GraphicsAPI, "graphics API: auto, vulkan, dx12, metal, gles, software")
@@ -380,6 +382,8 @@ func applyConfigValue(cfg *Config, section, key, value string) error {
 		return setInt(value, &cfg.Login.CharSlot)
 	case "audio.bgm":
 		return setBool(value, &cfg.Audio.BGM)
+	case "audio.noaudio":
+		return setBool(value, &cfg.Audio.Disabled)
 	case "audio.bgmvolume":
 		return setFloat(value, &cfg.Audio.BGMVolume)
 	case "audio.sfxvolume":

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,6 +87,7 @@ file = ./ignored.log
 		"--width", "1280",
 		"--fullscreen=false",
 		"--bgm=true",
+		"--no-audio=true",
 		"--bgm-volume", "0.75",
 		"--sfx-volume", "0.85",
 		"--graphics-api", "vulkan",
@@ -116,7 +117,7 @@ file = ./ignored.log
 	if cfg.Login.CharSlot != 3 {
 		t.Fatalf("login char slot = %d, want 3", cfg.Login.CharSlot)
 	}
-	if !cfg.Audio.BGM || cfg.Audio.BGMVolume != 0.75 || cfg.Audio.SFXVolume != 0.85 {
+	if !cfg.Audio.Disabled || !cfg.Audio.BGM || cfg.Audio.BGMVolume != 0.75 || cfg.Audio.SFXVolume != 0.85 {
 		t.Fatalf("unexpected audio config: %#v", cfg.Audio)
 	}
 	if cfg.Render.GraphicsAPI != "vulkan" || cfg.Render.VSync || !cfg.Render.FPS || cfg.Render.NoUI {


### PR DESCRIPTION
## Summary
- add a hard --no-audio configuration flag
- prevent BGM and SFX from initializing the audio backend when disabled
- skip zero-volume SFX before file decoding or context creation
- document the profiling-oriented flag

## Validation
- go test ./...`n- CGO_ENABLED=0 go test -tags nofakecgo ./...`n- CGO_ENABLED=0 go build -tags nofakecgo .`n
## Profiling result
On Windows ARM64, the hard-disable path removed all Oto/WASAPI samples from the CPU profile. Izlude FPS remained effectively unchanged, confirming that the WASAPI samples represented blocked audio-thread time rather than the render bottleneck.