### PR TITLE
Decouple glog from config package, and parse ini file as toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/kivutar/goro/glog"
 )
 
 type Config struct {
@@ -23,7 +26,7 @@ type Config struct {
 	Fog      FogConfig
 	Gameplay GameplayConfig
 	Script   ScriptConfig
-	Log      LogConfig
+	Log      glog.LogConfig
 }
 
 type WindowConfig struct {
@@ -85,11 +88,6 @@ type GameplayConfig struct {
 
 type ScriptConfig struct {
 	Path string
-}
-
-type LogConfig struct {
-	Level string
-	File  string
 }
 
 func LoadConfig(args []string) (Config, error) {
@@ -241,7 +239,7 @@ func defaultConfig() Config {
 		Gameplay: GameplayConfig{
 			NoCtrl: true,
 		},
-		Log: LogConfig{
+		Log: glog.LogConfig{
 			Level: "info",
 		},
 	}
@@ -336,113 +334,14 @@ func applyCLI(cfg *Config, args []string) error {
 }
 
 func applyINI(cfg *Config, r io.Reader) error {
-	scanner := bufio.NewScanner(r)
-	section := ""
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section = normalizeKey(strings.TrimSpace(line[1 : len(line)-1]))
-			continue
-		}
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			return fmt.Errorf("line %d: expected key=value", lineNo)
-		}
-		if err := applyConfigValue(cfg, section, normalizeKey(key), cleanINIValue(value)); err != nil {
-			return fmt.Errorf("line %d: %w", lineNo, err)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return validateConfig(cfg)
-}
+	b := bufio.NewScanner(r)
 
-func applyConfigValue(cfg *Config, section, key, value string) error {
-	switch section + "." + key {
-	case ".datadir", "data.dir", "data.datadir", "config.datadir", "core.datadir":
-		cfg.DataDir = value
-	case "window.title":
-		cfg.Window.Title = value
-	case "window.width":
-		return setInt(value, &cfg.Window.Width)
-	case "window.height":
-		return setInt(value, &cfg.Window.Height)
-	case "window.fullscreen":
-		return setBool(value, &cfg.Window.Fullscreen)
-	case "packet.clientdate":
-		return setInt(value, &cfg.Packet.ClientDate)
-	case "packet.profile":
-		return setInt(value, &cfg.Packet.Profile)
-	case "login.username":
-		cfg.Login.Username = value
-	case "login.password":
-		cfg.Login.Password = value
-	case "login.autologin":
-		return setBool(value, &cfg.Login.AutoLogin)
-	case "login.charslot":
-		return setInt(value, &cfg.Login.CharSlot)
-	case "audio.bgm":
-		return setBool(value, &cfg.Audio.BGM)
-	case "audio.noaudio":
-		return setBool(value, &cfg.Audio.Disabled)
-	case "audio.bgmvolume":
-		return setFloat(value, &cfg.Audio.BGMVolume)
-	case "audio.sfxvolume":
-		return setFloat(value, &cfg.Audio.SFXVolume)
-	case "render.graphicsapi":
-		cfg.Render.GraphicsAPI = value
-	case "render.vsync":
-		return setBool(value, &cfg.Render.VSync)
-	case "render.fps":
-		return setBool(value, &cfg.Render.FPS)
-	case "render.noui":
-		return setBool(value, &cfg.Render.NoUI)
-	case "render.asyncui":
-		return setBool(value, &cfg.Render.AsyncUI)
-	case "render.profileui":
-		return setBool(value, &cfg.Render.UIProfile)
-	case "render.benchseconds":
-		return setInt(value, &cfg.Render.BenchSeconds)
-	case "render.benchwarmupseconds":
-		return setInt(value, &cfg.Render.BenchWarmupSeconds)
-	case "render.cpuprofile":
-		cfg.Render.CPUProfile = value
-	case "render.stats":
-		return setBool(value, &cfg.Render.Stats)
-	case "render.worlddebugstats":
-		return setBool(value, &cfg.Render.WorldDebugStats)
-	case "network.trace":
-		return setBool(value, &cfg.Network.Trace)
-	case "fog.enabled":
-		return setBool(value, &cfg.Fog.Enabled)
-	case "gameplay.noshift":
-		return setBool(value, &cfg.Gameplay.NoShift)
-	case "gameplay.noctrl":
-		return setBool(value, &cfg.Gameplay.NoCtrl)
-	case "gameplay.lesseffects", "gameplay.lesseffect", "gameplay.mineffect", "gameplay.less_effects", "gameplay.less_effect":
-		return setBool(value, &cfg.Gameplay.LessEffects)
-	case "gameplay.snap", "gameplay.snaptargets", "gameplay.targetsnap":
-		return setBool(value, &cfg.Gameplay.SnapTargets)
-	case "gameplay.itemsnap", "gameplay.snapitems", "gameplay.itemsnapping":
-		return setBool(value, &cfg.Gameplay.SnapItems)
-	case "gameplay.forceuserai":
-		return setBool(value, &cfg.Gameplay.ForceUserAI)
-	case ".script", "script.path":
-		cfg.Script.Path = value
-	case "log.level":
-		cfg.Log.Level = strings.ToLower(value)
-	case "log.file":
-		cfg.Log.File = value
-	default:
-		return fmt.Errorf("unknown key %q in section %q", key, section)
+	_, err := toml.Decode(string(b.Bytes()), cfg)
+	if err != nil {
+		glog.Errorf("error decoding toml/ini file %v", err)
 	}
-	return nil
+
+	return validateConfig(cfg)
 }
 
 func validateConfig(cfg *Config) error {
@@ -587,42 +486,6 @@ func normalizeKey(value string) string {
 	value = strings.ReplaceAll(value, "-", "")
 	value = strings.ReplaceAll(value, "_", "")
 	return value
-}
-
-func setBool(raw string, dst *bool) error {
-	value, err := strconv.ParseBool(raw)
-	if err == nil {
-		*dst = value
-		return nil
-	}
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "yes", "on", "enabled":
-		*dst = true
-		return nil
-	case "no", "off", "disabled":
-		*dst = false
-		return nil
-	default:
-		return fmt.Errorf("invalid bool %q", raw)
-	}
-}
-
-func setInt(raw string, dst *int) error {
-	value, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil {
-		return fmt.Errorf("invalid int %q", raw)
-	}
-	*dst = value
-	return nil
-}
-
-func setFloat(raw string, dst *float64) error {
-	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
-	if err != nil {
-		return fmt.Errorf("invalid float %q", raw)
-	}
-	*dst = value
-	return nil
 }
 
 func resolveDataDir(value string) string {

--- a/game/login.go
+++ b/game/login.go
@@ -3,12 +3,13 @@ package game
 import (
 	"context"
 	"fmt"
-	"github.com/kivutar/goro/glog"
-	"github.com/kivutar/goro/input"
 	"image"
 	"image/color"
 	"strings"
 	"time"
+
+	"github.com/kivutar/goro/glog"
+	"github.com/kivutar/goro/input"
 
 	"github.com/kivutar/goro/client"
 	"github.com/kivutar/goro/network"

--- a/glog/logging.go
+++ b/glog/logging.go
@@ -9,12 +9,16 @@ import (
 	"strings"
 
 	charm "github.com/charmbracelet/log"
-	"github.com/kivutar/goro/config"
 )
 
 var logger = charm.Default()
 
-func Configure(cfg config.LogConfig) (func() error, error) {
+type LogConfig struct {
+	Level string
+	File  string
+}
+
+func Configure(cfg LogConfig) (func() error, error) {
 	level, err := parseLevel(cfg.Level)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=


### PR DESCRIPTION
Hello Jean,

I don't know if you would agree as I myself confess the suggestion in the PR is not 100% valid for INI files, but I'm keeping this on my branch for now to reduce the code complexity and length, as I'm still navigating the code base and trying to understand things around.

INI files are kind of a beast, they have different dialects and specific INI parsers might interpret things differently than each other.
However, syntactically they're similar to TOML files.
There's a fundamental difference that comments on INI files are `;` and in TOML are `#`.
This would be enough to reject the proposal that follows.
However, everything else, depending on the INI dialect, they are compatible with TOML, they're almost a barebones TOML subset.

Parsing the configuration files with TOML instead would remove about 150 lines of the hand made INI parser that is difficult to read and maintain.

In any case you reject and close this PR, I still suggest you to decouple glog from the config package.
As you probably know, it's a good practice to keep structs in the same package than their implementation.
LogConfig is a struct used to implement glog, however it's defined on config package instead.

It means that trying to use glog somewhere else might introduce a cyclic dependence with config, which generates a compilation error.