### PR TITLE
Implement 2008 stealth visibility and action restrictions

### DIFF
--- a/client/chat.go
+++ b/client/chat.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kivutar/goro/db"
 	"github.com/kivutar/goro/network"
 )
 
@@ -54,6 +55,9 @@ func SendChat(ctx Context, input string) error {
 
 // SetSitting requests a sit or stand action and updates the local player state.
 func SetSitting(ctx Context, sit bool) error {
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		return fmt.Errorf("cannot sit or stand while hiding")
+	}
 	if ctx.Network == nil {
 		return fmt.Errorf("not connected")
 	}

--- a/client/context.go
+++ b/client/context.go
@@ -31,6 +31,11 @@ type Context struct {
 	UIManager         UIManager
 }
 
+// PlayerHasEffectState reads the server's actor options, not status-icon timers.
+func (c Context) PlayerHasEffectState(mask uint32) bool {
+	return c.World != nil && c.World.Player.EffectState&mask != 0
+}
+
 type UIApp interface {
 	SetUIRoot(widget.Widget)
 	Frame()

--- a/docs/classic-ro-client-gap-checklist.md
+++ b/docs/classic-ro-client-gap-checklist.md
@@ -13,15 +13,26 @@ separate validation section and must not be implemented blindly.
 
 ### Stealth
 
-- [ ] Treat Hide, Cloaking, Invisible, and Chase Walk consistently when deciding how an actor is rendered.
-- [ ] Render the local player with the correct translucent/hidden-viewer appearance for every supported stealth state, not only `SC_HIDING`.
-- [ ] Apply the appropriate movement and input restrictions while the local player is hidden.
-- [ ] Exclude actors that should not be targetable or pickable while hidden.
-- [ ] Add focused tests for the local player, an allowed hidden viewer, an ordinary remote player, PvP, and WoE.
+- [x] Use server actor options for Hide, Cloaking, Invisible, and Chase Walk, independently of status-icon timers.
+- [x] Apply the 2008 hidden-viewer rendering rules to local and remote actors.
+- [x] Apply movement and action restrictions, including Tunnel Drive, the six skills usable while Hiding, and Chase Walk's own toggle.
+- [x] Exclude hidden actors from picking and targeting, and cancel queued actions when visibility changes.
+- [x] Suppress hidden actors' names, emblems, auras, carts, and falcons.
+- [x] Add focused rendering and packet tests for self, party, detection, GM, ordinary viewers, PvP, and WoE.
+- [ ] Compare the full flow visually against a running 2008 client and server.
 
-Current limitation: `localActorHidden` only checks `db.StatusHiding`, although
-the siege-emblem code already recognizes Hide, Cloak, Invisible, and Chase
-Walk as hidden states.
+The 2008 executable differs from classic-ro-client and the later dhxj source:
+Hiding keeps a shadow for self/GM, Cloaking hides even self and party bodies,
+Clairvoyance reveals a black body without a shadow, and Invisible remains
+unseen. The later translucent party view is deliberately not imported.
+Seeing a silhouette does not permit selecting a hidden target.
+
+Verified against `~/src/ro-client-re`'s `2008-09-10aSakexe.exe`:
+`CGameActor::SetAttrState` at `0x00572b80`, `CPc::Render` at `0x005e4920`,
+`CSession::IsMasterAid` at `0x006711a0`, and `CPlayer::SendMsg` at `0x005ee950`.
+The Ninja skill exceptions and server option combinations were also checked
+against `~/src/eathena/src/map/status.c` and rAthena. No new packets or
+duplicated stealth state are needed.
 
 ### Quest journal and markers
 

--- a/game/actor.go
+++ b/game/actor.go
@@ -66,6 +66,9 @@ func actorCanBeSkillTargeted(ctx client.Context, skill session.Skill, actor worl
 	if actor.ID == 0 || isWarpActor(actor) {
 		return false
 	}
+	if actorHasStealth(actor) && !isLocalActor(ctx, actor.ID) {
+		return false
+	}
 	targetFlags, ok := skillTargetFlagsForActor(ctx, actor)
 	if !ok {
 		return false
@@ -128,14 +131,14 @@ func skillTargetMapStateAllowsMismatch(ctx client.Context, actor worldstate.Acto
 }
 
 func actorCanOpenPlayerContext(ctx client.Context, actor worldstate.Actor) bool {
-	if isLocalActor(ctx, actor.ID) || strings.TrimSpace(actor.Name) == "" {
+	if actorHasStealth(actor) || isLocalActor(ctx, actor.ID) || strings.TrimSpace(actor.Name) == "" {
 		return false
 	}
 	return actorRepresentsPlayer(actor)
 }
 
 func actorCanBeAttackClicked(ctx client.Context, actor worldstate.Actor) bool {
-	if actor.ID == 0 || isLocalActor(ctx, actor.ID) {
+	if actor.ID == 0 || actorHasStealth(actor) || isLocalActor(ctx, actor.ID) {
 		return false
 	}
 	if actorRepresentsPlayer(actor) {
@@ -740,7 +743,7 @@ type sceneActorDrawEntry struct {
 	shadowDepth float64
 	depth       float64
 	isPlayer    bool
-	hidden      bool
+	stealth     stealthView
 }
 
 const (
@@ -788,6 +791,18 @@ func (m *WorldMode) drawSceneActors(screen *render.Frame, ctx client.Context, pr
 }
 
 func (m *WorldMode) drawSceneActorOverlays(screen *render.Frame, ctx client.Context, projection sceneProjection, now time.Time, entries []sceneActorDrawEntry) {
+	visible := make([]sceneActorDrawEntry, 0, len(entries))
+	for _, entry := range entries {
+		if actorHasStealth(entry.actor) {
+			if entry.isPlayer {
+				m.drawActorCastBar(screen, entry, now)
+				m.drawActorLifeBar(screen, ctx, entry)
+			}
+			continue
+		}
+		visible = append(visible, entry)
+	}
+	entries = visible
 	m.drawSiegeGuildEmblems(screen, ctx, projection, now, entries)
 	for _, entry := range entries {
 		m.drawActorCastBar(screen, entry, now)
@@ -855,23 +870,29 @@ func (m *WorldMode) collectSceneActorEntries(screen *render.Frame, ctx client.Co
 	}
 	player.Dir = ctx.World.Dir
 	entries = appendActorDrawEntry(entries, ctx.World, projection, player, true, now, width, height)
-	entries[len(entries)-1].hidden = localActorHidden(ctx)
 	for _, actor := range ctx.World.Actors {
 		if actor.ID == ctx.Session.AccountID || actor.ID == ctx.Session.CharID {
 			continue
 		}
 		entries = appendActorDrawEntry(entries, ctx.World, projection, actor, false, now, width, height)
 	}
-	return entries
+	visible := entries[:0]
+	for _, entry := range entries {
+		entry.stealth = actorStealthView(ctx, entry.actor, entry.isPlayer)
+		// The local gauges remain visible even when the body is absent.
+		if entry.isPlayer || entry.stealth != stealthHidden {
+			visible = append(visible, entry)
+		}
+	}
+	return visible
 }
 
 func (m *WorldMode) drawSceneActorEntry(screen *render.Frame, ctx client.Context, projection sceneProjection, entry sceneActorDrawEntry) {
-	cameraYaw := projection.cameraYaw
-	alpha := 1.0
-	if entry.hidden {
-		alpha = 0.35
+	if entry.stealth == stealthHidden || entry.stealth == stealthShadow {
+		return
 	}
-	alpha *= m.actorVisualAlpha(entry.actor.ID, time.Now())
+	cameraYaw := projection.cameraYaw
+	alpha := m.actorVisualAlpha(entry.actor.ID, time.Now())
 	if entry.isPlayer {
 		if !cartDrawAfterActor(entry.actor, cameraYaw) {
 			m.drawActorCart3D(screen, ctx, projection, entry, cameraYaw, entry.shadow, alpha)
@@ -907,7 +928,7 @@ func (m *WorldMode) drawActorShadowEntry(screen *render.Frame, ctx client.Contex
 	if !entry.castShadow || m.shadowView == nil || m.shadowViewMiss {
 		return
 	}
-	if entry.hidden {
+	if entry.stealth == stealthHidden || entry.stealth == stealthSilhouette {
 		return
 	}
 	if !entry.isPlayer && m.nonPCActorHasGR2Model(ctx, entry.actor) {
@@ -1450,7 +1471,7 @@ func (m *WorldMode) drawActorSprite3D(screen *render.Frame, ctx client.Context, 
 	if !ok {
 		return false
 	}
-	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.playerBodyRenderScale(actor.ID, actor.Job, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, m.actorRenderTint(actor, now))
+	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.playerBodyRenderScale(actor.ID, actor.Job, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, entry.stealth.tint(m.actorRenderTint(actor, now)))
 	return true
 }
 
@@ -1487,7 +1508,7 @@ func (m *WorldMode) drawMercenarySprite3D(screen *render.Frame, ctx client.Conte
 	if !ok {
 		return false
 	}
-	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.actorRenderScale(actor.ID, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, m.actorRenderTint(actor, now))
+	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.actorRenderScale(actor.ID, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, entry.stealth.tint(m.actorRenderTint(actor, now)))
 	return true
 }
 
@@ -1532,7 +1553,7 @@ func (m *WorldMode) drawNonPCSprite3D(screen *render.Frame, ctx client.Context, 
 	if !ok {
 		return false
 	}
-	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.actorRenderScale(actor.ID, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, m.actorRenderTint(actor, now))
+	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.actorRenderScale(actor.ID, entry.scale, now), m.actorVisualAlpha(actor.ID, now), shadow, entry.stealth.tint(m.actorRenderTint(actor, now)))
 	return true
 }
 

--- a/game/actor_state.go
+++ b/game/actor_state.go
@@ -20,12 +20,47 @@ func (m *WorldMode) applyActorStateChange(ctx client.Context, change network.Act
 		return
 	}
 	m.applyActorEffectStateEffects(ctx, change.ID, oldState, change.EffectState)
+	if (oldState^change.EffectState)&db.EffectStateHide != 0 {
+		m.addWorldEffect(ctx, effectSummonSlave, change.ID)
+		actor, _, _ := actorForCombatID(ctx, change.ID)
+		if change.EffectState&db.EffectStateHide != 0 && actor.Job != db.JobNinja {
+			m.addWorldEffect(ctx, effectBashBegin, change.ID)
+		}
+	}
+	if change.EffectState&actorStealthMask != 0 {
+		m.removeLevel99AuraEffects(change.ID)
+		delete(m.speechBubbles, change.ID)
+		if local {
+			m.removeLevel99AuraEffects(localSkillTarget(ctx))
+			delete(m.speechBubbles, localSkillTarget(ctx))
+		}
+	}
 	if local {
+		if !localStealthAllowsSkill(ctx, 0) {
+			m.cancelAttackIntent()
+		}
+		if ctx.PlayerHasEffectState(db.EffectStateHide) {
+			m.pendingPickup = pickupIntent{}
+		}
+		if !localStealthAllowsSkill(ctx, m.pendingSkill.skill.ID) {
+			m.pendingSkill = pendingSkillTarget{}
+		}
 		if newVisualJob := localPlayerVisualJob(ctx); newVisualJob != oldVisualJob {
 			m.reloadPlayerSpriteView(ctx, fmt.Sprintf("state effect=0x%08X", change.EffectState))
 		}
 		glog.Debugf("actor state local id=%d body=%d health=0x%04X effect=0x%08X", change.ID, change.BodyState, change.HealthState, change.EffectState)
 		return
+	}
+	if change.EffectState&actorStealthMask != 0 {
+		if m.pendingAttack.targetID == change.ID || m.lockedAttackID == change.ID {
+			m.cancelAttackIntent()
+		}
+		if m.pendingSkill.targetID == change.ID {
+			m.pendingSkill = pendingSkillTarget{}
+		}
+		if m.attackFocusID == change.ID {
+			m.clearAttackFocus()
+		}
 	}
 	glog.Debugf("actor state id=%d body=%d health=0x%04X effect=0x%08X", change.ID, change.BodyState, change.HealthState, change.EffectState)
 }

--- a/game/battle.go
+++ b/game/battle.go
@@ -254,6 +254,10 @@ func maxDuration(a, b time.Duration) time.Duration {
 }
 
 func (m *WorldMode) requestAttack(ctx client.Context, actor world.Actor, source string) {
+	if !localStealthAllowsSkill(ctx, 0) || actorHasStealth(actor) {
+		m.cancelAttackIntent()
+		return
+	}
 	if playerIsDead(ctx) {
 		return
 	}
@@ -472,6 +476,10 @@ func pendingAttackReadyAt(player world.Actor, now time.Time) time.Time {
 }
 
 func (m *WorldMode) sendAttackAction(ctx client.Context, actor world.Actor, source string) {
+	if !localStealthAllowsSkill(ctx, 0) || actorHasStealth(actor) {
+		m.cancelAttackIntent()
+		return
+	}
 	if err := ctx.Network.SendActionRequest(actor.ID, network.ActionAttack); err == nil {
 		m.lastAttackAt = time.Now()
 		m.setWalkCooldown(walkRequestCooldown)

--- a/game/cart.go
+++ b/game/cart.go
@@ -215,7 +215,7 @@ func (m *WorldMode) cartSpriteView(ctx client.Context, cartNum int) *spriteView 
 
 func (m *WorldMode) drawActorCart3D(screen *render.Frame, ctx client.Context, projection sceneProjection, entry sceneActorDrawEntry, cameraYaw float64, shadow float64, alpha float64) bool {
 	actor := entry.actor
-	if !res.HasPlayerJobToken(int(actor.Job)) {
+	if actorHasStealth(actor) || !res.HasPlayerJobToken(int(actor.Job)) {
 		return false
 	}
 	hasCart, cartNum := actorCartState(actor)
@@ -256,7 +256,7 @@ func (m *WorldMode) drawActorCart3D(screen *render.Frame, ctx client.Context, pr
 
 func (m *WorldMode) drawActorCartShadow3D(screen *render.Frame, ctx client.Context, projection sceneProjection, entry sceneActorDrawEntry, cameraYaw float64, now time.Time) bool {
 	actor := entry.actor
-	if !entry.castShadow || entry.hidden || m.shadowView == nil || m.shadowViewMiss || !res.HasPlayerJobToken(int(actor.Job)) {
+	if !entry.castShadow || actorHasStealth(actor) || m.shadowView == nil || m.shadowViewMiss || !res.HasPlayerJobToken(int(actor.Job)) {
 		return false
 	}
 	if hasCart, _ := actorCartState(actor); !hasCart {

--- a/game/cursor.go
+++ b/game/cursor.go
@@ -417,7 +417,7 @@ func hoveredCursorActor(ctx client.Context, projection sceneProjection, mouseX, 
 		if _, dead := deadActors[actor.ID]; dead {
 			continue
 		}
-		if isLocalActor(ctx, actor.ID) || actor.ID == 0 {
+		if actorHasStealth(actor) || isLocalActor(ctx, actor.ID) || actor.ID == 0 {
 			continue
 		}
 		if int(actor.Job) == actorJobClearNPC {

--- a/game/falcon.go
+++ b/game/falcon.go
@@ -275,15 +275,11 @@ func (m *WorldMode) drawSceneActorFalcons(screen *render.Frame, ctx client.Conte
 	now := time.Now()
 	activeOwners := make(map[uint32]struct{})
 	for _, entry := range entries {
-		if !actorHasFalcon(entry.actor) {
+		if actorHasStealth(entry.actor) || !actorHasFalcon(entry.actor) {
 			continue
 		}
 		activeOwners[entry.actor.ID] = struct{}{}
-		alpha := 1.0
-		if entry.hidden {
-			alpha = 0.35
-		}
-		alpha *= m.actorVisualAlpha(entry.actor.ID, now)
+		alpha := m.actorVisualAlpha(entry.actor.ID, now)
 		m.drawActorFalcon3D(screen, ctx, projection, entry.actor, projection.cameraYaw, alpha, now)
 	}
 	m.pruneFalconStates(activeOwners)

--- a/game/gr2_model.go
+++ b/game/gr2_model.go
@@ -50,7 +50,7 @@ func (m *WorldMode) drawNonPCGR2Model3D(screen *render.Frame, ctx client.Context
 	if ctx.World != nil {
 		lighting = m.sceneLighting(ctx.World.RSW)
 	}
-	tint := m.actorRenderTint(actor, now)
+	tint := entry.stealth.tint(m.actorRenderTint(actor, now))
 	alpha := m.actorVisualAlpha(actor.ID, now)
 	if alpha <= 0 {
 		return true

--- a/game/guild_emblem.go
+++ b/game/guild_emblem.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/kivutar/goro/client"
-	"github.com/kivutar/goro/db"
 	"github.com/kivutar/goro/glog"
 	"github.com/kivutar/goro/network"
 	"github.com/kivutar/goro/render"
@@ -227,8 +226,7 @@ func (m *WorldMode) drawSiegeGuildEmblems(screen *render.Frame, ctx client.Conte
 }
 
 func siegeActorShowsGuildEmblem(entry sceneActorDrawEntry) bool {
-	const hiddenEffectMask = db.EffectStateHide | db.EffectStateCloak | db.EffectStateInvisible | db.EffectStateChasewalk
-	return !entry.hidden && entry.actor.EffectState&hiddenEffectMask == 0 && entry.actor.GuildID != 0 && entry.actor.EmblemVersion != 0
+	return !actorHasStealth(entry.actor) && entry.actor.GuildID != 0 && entry.actor.EmblemVersion != 0
 }
 
 func (m *WorldMode) siegeGuildEmblemAnchor(ctx client.Context, projection sceneProjection, now time.Time, entry sceneActorDrawEntry) (float64, float64) {

--- a/game/guild_test.go
+++ b/game/guild_test.go
@@ -436,11 +436,10 @@ func TestSiegeGuildEmblemEligibilityAndPosition(t *testing.T) {
 	if !siegeActorShowsGuildEmblem(entry) {
 		t.Fatal("visible guild actor did not qualify for a siege emblem")
 	}
-	entry.hidden = true
+	entry.actor.EffectState = db.EffectStateHide
 	if siegeActorShowsGuildEmblem(entry) {
 		t.Fatal("hidden actor qualified for a siege emblem")
 	}
-	entry.hidden = false
 	entry.actor.EffectState = db.EffectStateCloak
 	if siegeActorShowsGuildEmblem(entry) {
 		t.Fatal("cloaked actor qualified for a siege emblem")

--- a/game/items.go
+++ b/game/items.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/db"
 	"github.com/kivutar/goro/glog"
 	"image"
 	"image/color"
@@ -140,6 +141,9 @@ func itemPickupAckAddsItem(ack network.ItemPickupAck) bool {
 }
 
 func (m *WorldMode) requestPickup(ctx client.Context, item worldstate.FloorItem, source string) bool {
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		return false
+	}
 	if playerIsDead(ctx) {
 		return false
 	}
@@ -247,6 +251,9 @@ func pendingPickupReadyAt(player worldstate.Actor, now time.Time) time.Time {
 }
 
 func (m *WorldMode) sendPickupRequest(ctx client.Context, item worldstate.FloorItem, source string) bool {
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		return false
+	}
 	if err := ctx.Network.SendItemPickup(item.ID); err == nil {
 		m.facePlayerTowardItem(ctx, item)
 		m.setWalkCooldown(walkRequestCooldown)

--- a/game/level99_aura.go
+++ b/game/level99_aura.go
@@ -47,6 +47,10 @@ func (m *WorldMode) syncActorLevel99AuraEffects(ctx client.Context, actorID uint
 	if !hasLevel {
 		return
 	}
+	if actor, ok, _ := actorForCombatID(ctx, actorID); ok && actorHasStealth(actor) {
+		m.removeLevel99AuraEffects(actorID)
+		return
+	}
 	var wanted []int
 	if level >= level99AuraLevel {
 		wanted = level99AuraEffectIDs(ctx)

--- a/game/movement.go
+++ b/game/movement.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/db"
 	"github.com/kivutar/goro/network"
 	"github.com/kivutar/goro/res"
 	worldstate "github.com/kivutar/goro/world"
@@ -151,6 +152,9 @@ func actorCurrentCell(actor worldstate.Actor, now time.Time) (int, int) {
 
 func (m *WorldMode) requestWalk(ctx client.Context, targetX, targetY int, source string) bool {
 	if playerIsDead(ctx) {
+		return false
+	}
+	if ctx.PlayerHasEffectState(db.EffectStateHide) && learnedSkillLevel(ctx.Session, db.SkillRGTunneldrive) == 0 {
 		return false
 	}
 	if ctx.World == nil || ctx.Network == nil || !walkTargetInBounds(ctx, targetX, targetY) {

--- a/game/skill_use.go
+++ b/game/skill_use.go
@@ -241,6 +241,9 @@ const skillChangeCart = 154
 const skillGroundTextMaxBytes = 79
 
 func (c skillController) Use(ctx client.Context, skill session.Skill, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, 0); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -289,6 +292,9 @@ func (c skillController) Use(ctx client.Context, skill session.Skill, source str
 }
 
 func (c skillController) SendToID(ctx client.Context, skill session.Skill, target uint32, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, target); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -320,6 +326,9 @@ func (c skillController) SendToID(ctx client.Context, skill session.Skill, targe
 }
 
 func (c skillController) SendToGround(ctx client.Context, skill session.Skill, x, y int, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, 0); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -341,6 +350,9 @@ func (c skillController) SendToGround(ctx client.Context, skill session.Skill, x
 }
 
 func (c skillController) SendToGroundWithText(ctx client.Context, skill session.Skill, x, y int, text string, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, 0); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -455,6 +467,9 @@ func (c skillController) HandleClick(ctx client.Context, projection sceneProject
 }
 
 func (c skillController) UseTarget(ctx client.Context, skill session.Skill, actor worldstate.Actor, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, actor.ID); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -484,6 +499,9 @@ func skillNeedsGroundText(skillID uint16) bool {
 }
 
 func (c skillController) UseGround(ctx client.Context, skill session.Skill, x, y int, text, source string) error {
+	if err := checkStealthSkill(ctx, skill.ID, 0); err != nil {
+		return err
+	}
 	if playerIsDead(ctx) {
 		return fmt.Errorf("player is dead")
 	}
@@ -516,11 +534,14 @@ func (pending pendingSkillTarget) hasTarget() bool {
 }
 
 func (pending pendingSkillTarget) targetCell(ctx client.Context, now time.Time) (int, int, bool) {
+	if !localStealthAllowsSkill(ctx, pending.skill.ID) {
+		return 0, 0, false
+	}
 	if pending.ground {
 		return pending.x, pending.y, walkTargetInBounds(ctx, pending.x, pending.y)
 	}
 	actor, ok := ctx.World.Actors[pending.targetID]
-	if !ok {
+	if !ok || actorHasStealth(actor) {
 		return 0, 0, false
 	}
 	x, y := actorCurrentCell(actor, now)

--- a/game/sprite_render.go
+++ b/game/sprite_render.go
@@ -199,7 +199,7 @@ func (m *WorldMode) drawPlayerSprite3D(ctx client.Context, screen *render.Frame,
 	if !ok {
 		return false
 	}
-	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.playerRenderScale(ctx, actor, entry.scale, now), alpha, shadow, m.playerRenderTint(ctx, actor, now))
+	drawActorSpriteBillboardTintAlpha3D(screen, projection, billboard, entry.worldX, entry.worldY, entry.worldZ, m.playerRenderScale(ctx, actor, entry.scale, now), alpha, shadow, entry.stealth.tint(m.playerRenderTint(ctx, actor, now)))
 	return true
 }
 

--- a/game/status_effects.go
+++ b/game/status_effects.go
@@ -25,7 +25,6 @@ func (m *WorldMode) applyStatusEffectChange(ctx client.Context, change network.S
 	if !applyLocalStatusEffectChange(ctx.Session, change, time.Now()) {
 		return
 	}
-	m.addStatusEffectTransition(ctx, change)
 	if !change.Active {
 		glog.Debugf("status effect inactive id=%d actor=%d", change.StatusID, change.ActorID)
 		return
@@ -215,19 +214,6 @@ func (m *WorldMode) setTrickDeadStatusAction(ctx client.Context, id uint32, acti
 	})
 }
 
-func (m *WorldMode) addStatusEffectTransition(ctx client.Context, change network.StatusEffectChange) {
-	if change.StatusID != db.StatusHiding {
-		return
-	}
-	effectID := effectSummonSlave
-	if change.Active {
-		effectID = effectBashBegin
-	}
-	if m.addWorldEffect(ctx, effectID, localSkillTarget(ctx)) {
-		glog.Debugf("status effect transition id=%d active=%t effect=%d", change.StatusID, change.Active, effectID)
-	}
-}
-
 func removeExpiredStatusEffects(s *session.Session, now time.Time) {
 	if s == nil {
 		return
@@ -245,8 +231,4 @@ func localActorHasStatus(ctx client.Context, statusID uint16) bool {
 	}
 	_, ok := ctx.Session.Statuses.Active[statusID]
 	return ok
-}
-
-func localActorHidden(ctx client.Context) bool {
-	return localActorHasStatus(ctx, db.StatusHiding)
 }

--- a/game/stealth.go
+++ b/game/stealth.go
@@ -1,0 +1,81 @@
+package game
+
+import (
+	"fmt"
+	"image/color"
+
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/db"
+	worldstate "github.com/kivutar/goro/world"
+)
+
+const actorStealthMask = db.EffectStateHide | db.EffectStateCloak | db.EffectStateInvisible | db.EffectStateChasewalk
+
+type stealthView uint8
+
+const (
+	stealthVisible stealthView = iota
+	stealthHidden
+	stealthShadow
+	stealthSilhouette
+)
+
+func actorHasStealth(actor worldstate.Actor) bool {
+	return actor.EffectState&actorStealthMask != 0
+}
+
+// The 2008 Sakexe hides cloaked bodies, including self and party members.
+// CPc::Render (0x005e4920) reveals them only through Clairvoyance, in black.
+// CGameActor::SetAttrState (0x00572b80) keeps Hiding shadows for self/GM;
+// Invisible takes precedence and is not revealed by Clairvoyance.
+func actorStealthView(ctx client.Context, actor worldstate.Actor, local bool) stealthView {
+	if !actorHasStealth(actor) {
+		return stealthVisible
+	}
+	if actor.EffectState&db.EffectStateInvisible != 0 {
+		return stealthHidden
+	}
+	if localActorHasStatus(ctx, db.StatusClairvoyance) {
+		return stealthSilhouette
+	}
+	if actor.EffectState&(db.EffectStateCloak|db.EffectStateChasewalk) == 0 && (local || localPlayerIsAdmin(ctx)) {
+		return stealthShadow
+	}
+	return stealthHidden
+}
+
+func (v stealthView) tint(tint color.RGBA) color.RGBA {
+	if v == stealthSilhouette {
+		tint.R, tint.G, tint.B = 0, 0, 0
+	}
+	return tint
+}
+
+func localStealthAllowsSkill(ctx client.Context, skillID uint16) bool {
+	// Commands to companions are independent of their owner's stealth.
+	if skillCasterKindForID(skillID) != skillCasterPlayer {
+		return true
+	}
+	if ctx.PlayerHasEffectState(db.EffectStateChasewalk) {
+		return skillID == db.SkillSTChasewalk
+	}
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		switch skillID {
+		case db.SkillTFHiding, db.SkillASGrimtooth, db.SkillRGBackstap, db.SkillRGRaid, db.SkillNJShadowjump, db.SkillNJKirikage:
+			return true
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func checkStealthSkill(ctx client.Context, skillID uint16, targetID uint32) error {
+	if !localStealthAllowsSkill(ctx, skillID) {
+		return fmt.Errorf("skill cannot be used while hidden")
+	}
+	if actor, ok, local := actorForCombatID(ctx, targetID); ok && !local && actorHasStealth(actor) {
+		return fmt.Errorf("target is hidden")
+	}
+	return nil
+}

--- a/game/stealth_test.go
+++ b/game/stealth_test.go
@@ -1,0 +1,261 @@
+package game
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/db"
+	"github.com/kivutar/goro/network"
+	"github.com/kivutar/goro/render"
+	"github.com/kivutar/goro/res"
+	"github.com/kivutar/goro/session"
+	gameui "github.com/kivutar/goro/ui"
+	worldstate "github.com/kivutar/goro/world"
+)
+
+func stealthTestContext() client.Context {
+	w := worldstate.New()
+	w.Player = worldstate.Actor{ID: 100, X: 10, Y: 20, HasState: true}
+	w.GAT = &res.GAT{Width: 32, Height: 32, Cells: make([]res.GATCell, 32*32)}
+	return client.Context{World: w, Session: &session.Session{
+		AccountID: 100, CharID: 200, Vitals: session.Vitals{HP: 100},
+		Selected: session.Character{ID: 200, HP: 100},
+	}, ScreenW: 800, ScreenH: 600}
+}
+
+func TestStealthVisibilityAndPicking2008(t *testing.T) {
+	for _, mapProperty := range []worldstate.MapProperty{worldstate.MapPropertyNothing, worldstate.MapPropertyFreePvPZone, worldstate.MapPropertyAgitZone} {
+		for _, viewer := range []string{"self", "party", "other", "detection", "self detection", "GM"} {
+			for _, state := range []uint32{0, db.EffectStateHide, db.EffectStateCloak, db.EffectStateChasewalk, db.EffectStateCloak | db.EffectStateChasewalk, db.EffectStateInvisible, actorStealthMask} {
+				t.Run(fmt.Sprintf("map=%d/%s/option=%x", mapProperty, viewer, state), func(t *testing.T) {
+					ctx := stealthTestContext()
+					ctx.World.MapProperty = mapProperty
+					actor := worldstate.Actor{ID: 300, X: 10, Y: 20, Job: db.JobAssassin, Name: "Hidden player", GuildID: 2, EmblemVersion: 1, Appearance: true, HasState: true, EffectState: state}
+					local := viewer == "self" || viewer == "self detection"
+					detection := viewer == "detection" || viewer == "self detection"
+					if local {
+						ctx.World.Player.EffectState = state
+						actor.ID = ctx.Session.CharID
+					} else {
+						ctx.World.UpsertActor(actor)
+					}
+					if viewer == "party" {
+						ctx.Session.Party.Members = []session.PartyMember{{AccountID: actor.ID}}
+					}
+					if detection {
+						ctx.Session.Statuses.Active = map[uint16]session.StatusEffect{db.StatusClairvoyance: {}}
+					}
+					if viewer == "GM" {
+						ctx.Session.AdminList = []uint32{ctx.Session.AccountID}
+					}
+					want := stealthHidden
+					switch {
+					case state == 0:
+						want = stealthVisible
+					case state&db.EffectStateInvisible != 0:
+					case detection:
+						want = stealthSilhouette
+					case state == db.EffectStateHide && (local || viewer == "GM"):
+						want = stealthShadow
+					}
+					projection := newSceneProjectionForTarget(800, 600, cellCenter(10), cellCenter(20), 0)
+					mode := &WorldMode{}
+					entries := mode.collectSceneActorEntries(render.NewFrame(800, 600), ctx, projection)
+					found := false
+					for _, entry := range entries {
+						if entry.actor.ID == actor.ID {
+							found = true
+							if entry.stealth != want {
+								t.Fatalf("render view = %d, want %d", entry.stealth, want)
+							}
+						}
+					}
+					if found != (local || want != stealthHidden) {
+						t.Fatalf("actor in draw list = %t, want view %d", found, want)
+					}
+					if !local && state != 0 {
+						if _, ok := hoveredCursorActor(ctx, projection, 400, 300, time.Now(), nil); ok {
+							t.Fatal("hidden actor was hoverable")
+						}
+						if actorCanBeAttackClicked(ctx, actor) || actorCanOpenPlayerContext(ctx, actor) || actorCanBeSkillTargeted(ctx, session.Skill{ID: db.SkillALHeal, Type: skillTargetFriend}, actor) {
+							t.Fatal("hidden actor was targetable")
+						}
+						if siegeActorShowsGuildEmblem(sceneActorDrawEntry{actor: actor}) {
+							t.Fatal("hidden actor exposed its guild emblem")
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestStealthDrawsShadowOrBlackBody(t *testing.T) {
+	sprite := &spriteView{
+		spr:    &res.SPR{Frames: []res.SPRFrame{{Type: res.SPRFrameRGBA, Width: 8, Height: 8, Data: solidRGBAFrame(8, 8)}}},
+		act:    &res.ACT{Actions: []res.ACTAction{{DelayMS: 100, Animations: []res.ACTAnimation{{Layers: []res.ACTLayer{{Index: 0, SPRType: res.SPRFrameRGBA, ScaleX: 1, ScaleY: 1, Color: [4]float32{1, 1, 1, 1}}}}}}}},
+		images: make(map[spriteFrameKey]*render.Image), billboards: make(map[singleSpriteBillboardKey]*spriteBillboard),
+	}
+	mode := &WorldMode{shadowView: sprite, playerView: &humanoidSpriteView{body: sprite, billboards: make(map[humanoidBillboardKey]*spriteBillboard)}}
+	ctx := stealthTestContext()
+	projection := newSceneProjectionForTarget(800, 600, cellCenter(10), cellCenter(20), 0)
+	for _, tc := range []struct {
+		view         stealthView
+		body, shadow bool
+	}{{stealthVisible, true, true}, {stealthShadow, false, true}, {stealthSilhouette, true, false}, {stealthHidden, false, false}} {
+		t.Run(fmt.Sprint(tc.view), func(t *testing.T) {
+			entry := mode.collectSceneActorEntries(render.NewFrame(800, 600), ctx, projection)[0]
+			entry.stealth = tc.view
+			frame := render.NewFrame(800, 600)
+			mode.drawSceneActorEntry(frame, ctx, projection, entry)
+			commands := reflect.ValueOf(frame).Elem().FieldByName("worldBillboards")
+			if (commands.Len() > 0) != tc.body {
+				t.Fatalf("body draws = %d, want body=%t", commands.Len(), tc.body)
+			}
+			if tc.view == stealthSilhouette {
+				for _, channel := range []string{"ColorR", "ColorG", "ColorB"} {
+					if commands.Index(0).FieldByName(channel).Float() != 0 {
+						t.Fatal("detected body was not black")
+					}
+				}
+				if commands.Index(0).FieldByName("ColorA").Float() != 1 {
+					t.Fatal("detected body was translucent")
+				}
+			}
+			frame.BeginFrame()
+			mode.drawActorShadowEntry(frame, ctx, projection, entry)
+			commands = reflect.ValueOf(frame).Elem().FieldByName("worldBillboards")
+			if (commands.Len() > 0) != tc.shadow {
+				t.Fatalf("shadow draws = %d, want shadow=%t", commands.Len(), tc.shadow)
+			}
+		})
+	}
+}
+
+func TestStealthActionPackets(t *testing.T) {
+	ctx := stealthTestContext()
+	netClient, server := newBotTestConnection(t, 20080910)
+	ctx.Network = netClient
+	mode := &WorldMode{}
+	actor := worldstate.Actor{ID: 300, X: 11, Y: 20, Job: 1002, HasObjectType: true, ObjectType: actorObjectTypeMob, HasState: true}
+	ctx.World.UpsertActor(actor)
+	item := session.InventoryItem{Index: 7, ItemID: 501, Type: db.ItemTypeHealing}
+	floorItem := worldstate.FloorItem{ID: 400, X: 10, Y: 20}
+	ctx.World.Player.EffectState = db.EffectStateHide
+	ctx.Session.Skills.List = []session.Skill{{ID: db.SkillRGTunneldrive, Level: 0}}
+	assertNoBotTestPacket(t, server, func() error {
+		if mode.requestWalk(ctx, 11, 20, "test") || mode.requestPickup(ctx, floorItem, "test") {
+			t.Fatal("Hiding allowed movement or pickup")
+		}
+		mode.requestAttack(ctx, actor, "test")
+		if client.SetSitting(ctx, true) == nil || gameui.UseInventoryItem(ctx, item) == nil {
+			t.Fatal("Hiding allowed sitting or item use")
+		}
+		if mode.skills().Use(ctx, session.Skill{ID: db.SkillALHeal, Level: 1, Type: skillTargetFriend, Range: 9}, "test") == nil || mode.pendingSkill.skill.ID != 0 {
+			t.Fatal("Hiding started a forbidden skill")
+		}
+		return nil
+	})
+	ctx.Session.Skills.List = []session.Skill{{ID: db.SkillRGTunneldrive, Level: 1}}
+	if !mode.requestWalk(ctx, 11, 20, "test") {
+		t.Fatal("Tunnel Drive could not walk")
+	}
+	walk, _ := network.BuildWalkToXYPacketForClientDate(11, 20, 20080910)
+	readBotTestPackets(t, server, walk)
+	for _, id := range []uint16{db.SkillTFHiding, db.SkillASGrimtooth, db.SkillRGBackstap, db.SkillRGRaid, db.SkillNJShadowjump, db.SkillNJKirikage} {
+		skill := session.Skill{ID: id, Level: 1}
+		if err := mode.skills().SendToID(ctx, skill, ctx.Session.AccountID, "test"); err != nil {
+			t.Fatalf("allowed hidden skill %d: %v", id, err)
+		}
+		readBotTestPackets(t, server, network.BuildUseSkillToIDPacketForClientDate(id, 1, ctx.Session.AccountID, 20080910))
+	}
+	ctx.World.Player.EffectState = db.EffectStateCloak | db.EffectStateChasewalk
+	assertNoBotTestPacket(t, server, func() error {
+		mode.requestAttack(ctx, actor, "test")
+		if mode.skills().SendToGround(ctx, session.Skill{ID: db.SkillWZStormgust, Level: 1}, 11, 20, "test") == nil {
+			t.Fatal("Chase Walk allowed another skill")
+		}
+		return nil
+	})
+	if err := mode.skills().Use(ctx, session.Skill{ID: db.SkillSTChasewalk, Type: skillTargetSelf, Level: 1}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	readBotTestPackets(t, server, network.BuildUseSkillToIDPacketForClientDate(db.SkillSTChasewalk, 1, ctx.Session.AccountID, 20080910))
+	ctx.World.Player.EffectState = db.EffectStateCloak
+	mode.requestAttack(ctx, actor, "test")
+	readLegacyBotTestActionPacket(t, server, actor.ID, network.ActionAttack)
+	if err := gameui.UseInventoryItem(ctx, item); err != nil {
+		t.Fatal(err)
+	}
+	readBotTestPackets(t, server, network.BuildUseInventoryItemPacketForClientDate(item.Index, ctx.Session.AccountID, 20080910))
+	actor.EffectState = db.EffectStateHide
+	ctx.World.UpsertActor(actor)
+	assertNoBotTestPacket(t, server, func() error {
+		mode.requestAttack(ctx, actor, "test")
+		if mode.skills().SendToID(ctx, session.Skill{ID: db.SkillALHeal, Level: 1}, actor.ID, "test") == nil {
+			t.Fatal("direct skill send targeted a hidden actor")
+		}
+		return nil
+	})
+}
+
+func TestStealthDoesNotRestrictCompanionSkills(t *testing.T) {
+	ctx := stealthTestContext()
+	ctx.World.Player.EffectState = db.EffectStateHide | db.EffectStateChasewalk
+	if !localStealthAllowsSkill(ctx, db.SkillHomunBegin+1) || !localStealthAllowsSkill(ctx, db.SkillMercenaryBegin+1) {
+		t.Fatal("owner stealth restricted a companion's skills")
+	}
+}
+
+func TestStealthCollectionHandlesPlayerOutsideViewport(t *testing.T) {
+	ctx := stealthTestContext()
+	ctx.World.Player.X = 100000
+	ctx.World.Player.EffectState = db.EffectStateHide
+	projection := newSceneProjectionForTarget(800, 600, 0, 0, 0)
+	mode := &WorldMode{}
+	if entries := mode.collectSceneActorEntries(render.NewFrame(800, 600), ctx, projection); len(entries) != 0 {
+		t.Fatal("offscreen player remained in the draw list")
+	}
+}
+
+func TestStealthCancelsQueuedActionsAndHidesAttachments(t *testing.T) {
+	ctx := stealthTestContext()
+	actor := worldstate.Actor{ID: 300, Job: db.JobAssassin, X: 11, Y: 20, HasLevel: true, Level: 99, Appearance: true, HasState: true}
+	ctx.World.UpsertActor(actor)
+	mode := &WorldMode{}
+	mode.syncLevel99AuraEffects(ctx, time.Now())
+	if len(mode.worldEffects) == 0 {
+		t.Fatal("missing initial level aura")
+	}
+	mode.pendingAttack = attackIntent{targetID: actor.ID}
+	mode.lockedAttackID, mode.attackFocusID = actor.ID, actor.ID
+	mode.pendingSkill = pendingSkillTarget{skill: session.Skill{ID: db.SkillALHeal}, targetID: actor.ID}
+	mode.applyActorStateChange(ctx, network.ActorStateChange{ID: actor.ID, EffectState: db.EffectStateCloak})
+	mode.syncLevel99AuraEffects(ctx, time.Now())
+	if mode.pendingAttack.targetID != 0 || mode.lockedAttackID != 0 || mode.attackFocusID != 0 || mode.pendingSkill.skill.ID != 0 || len(mode.worldEffects) != 0 {
+		t.Fatal("hidden target retained an action or aura")
+	}
+	mode.applyActorStateChange(ctx, network.ActorStateChange{ID: actor.ID})
+	mode.syncLevel99AuraEffects(ctx, time.Now())
+	if len(mode.worldEffects) == 0 {
+		t.Fatal("revealed actor did not regain its aura")
+	}
+	mode.pendingAttack = attackIntent{targetID: actor.ID}
+	mode.pendingPickup = pickupIntent{itemID: 400}
+	mode.pendingSkill = pendingSkillTarget{skill: session.Skill{ID: db.SkillALHeal}, targetID: actor.ID}
+	mode.applyActorStateChange(ctx, network.ActorStateChange{ID: ctx.Session.AccountID, EffectState: db.EffectStateHide})
+	if mode.pendingAttack.targetID != 0 || mode.pendingPickup.itemID != 0 || mode.pendingSkill.skill.ID != 0 {
+		t.Fatal("Hiding retained a queued local action")
+	}
+	entry := sceneActorDrawEntry{actor: worldstate.Actor{ID: 100, EffectState: db.EffectStateHide | db.EffectStateCart1 | db.EffectStateFalcon, HasCart: true, HasCartState: true}}
+	if mode.drawActorCart3D(nil, ctx, sceneProjection{}, entry, 0, 1, 1) {
+		t.Fatal("hidden cart was drawn")
+	}
+	mode.drawSceneActorFalcons(nil, ctx, sceneProjection{}, []sceneActorDrawEntry{entry})
+	if len(mode.falcons) != 0 {
+		t.Fatal("hidden actor created a falcon")
+	}
+}

--- a/game/world_mode_actor_state_test.go
+++ b/game/world_mode_actor_state_test.go
@@ -80,35 +80,31 @@ func TestApplyStatusEffectChangeTracksLocalStatus(t *testing.T) {
 	}
 }
 
-func TestApplyHidingStatusTogglesLocalHiddenStateAndTransitionEffects(t *testing.T) {
-	world := worldstate.New()
-	world.Player = worldstate.Actor{ID: 150000, X: 10, Y: 20}
-	sessionState := &session.Session{AccountID: 2000000, CharID: 150000}
-	ctx := client.Context{Session: sessionState, World: world}
+func TestHidingUsesActorOptionsInsteadOfStatusIcons(t *testing.T) {
+	ctx := client.Context{
+		World:   worldstate.New(),
+		Session: &session.Session{AccountID: 2000000, CharID: 150000},
+	}
+	ctx.World.Player = worldstate.Actor{ID: 2000000, X: 10, Y: 20}
 	mode := &WorldMode{}
-
-	mode.applyStatusEffectChange(ctx, network.StatusEffectChange{
-		StatusID: db.StatusHiding,
-		ActorID:  2000000,
-		Active:   true,
-	})
-	if !localActorHidden(ctx) {
-		t.Fatal("hiding status did not mark the local actor hidden")
+	mode.applyStatusEffectChange(ctx, network.StatusEffectChange{StatusID: db.StatusHiding, ActorID: 2000000, Active: true, HasDuration: true, Duration: time.Second})
+	if ctx.PlayerHasEffectState(db.EffectStateHide) || len(mode.worldEffects) != 0 {
+		t.Fatal("status icon changed actor visibility or duplicated its transition")
 	}
-	if len(mode.worldEffects) != 1 || mode.worldEffects[0].effectID != effectBashBegin {
-		t.Fatalf("hide enter effects = %+v, want EF_BASH", mode.worldEffects)
+	change := network.ActorStateChange{ID: 2000000, EffectState: db.EffectStateHide}
+	mode.applyActorStateChange(ctx, change)
+	mode.applyActorStateChange(ctx, change)
+	removeExpiredStatusEffects(ctx.Session, time.Now().Add(time.Hour))
+	if !ctx.PlayerHasEffectState(db.EffectStateHide) {
+		t.Fatal("status icon expiry revealed the player")
 	}
-
-	mode.applyStatusEffectChange(ctx, network.StatusEffectChange{
-		StatusID: db.StatusHiding,
-		ActorID:  2000000,
-		Active:   false,
-	})
-	if localActorHidden(ctx) {
-		t.Fatal("inactive hiding status still marks the local actor hidden")
+	if len(mode.worldEffects) != 2 || mode.worldEffects[0].effectID != effectSummonSlave || mode.worldEffects[1].effectID != effectBashBegin {
+		t.Fatalf("hide effects = %+v, want one transition", mode.worldEffects)
 	}
-	if len(mode.worldEffects) != 2 || mode.worldEffects[1].effectID != effectSummonSlave {
-		t.Fatalf("hide exit effects = %+v, want EF_SUMMONSLAVE", mode.worldEffects)
+	change.EffectState = 0
+	mode.applyActorStateChange(ctx, change)
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		t.Fatal("actor remained hidden after option cleared")
 	}
 }
 

--- a/ui/inventory_actions.go
+++ b/ui/inventory_actions.go
@@ -10,6 +10,9 @@ import (
 
 // UseInventoryItem requests use of a consumable inventory entry.
 func UseInventoryItem(ctx Context, item session.InventoryItem) error {
+	if ctx.PlayerHasEffectState(db.EffectStateHide) {
+		return fmt.Errorf("cannot use items while hiding")
+	}
 	if ctx.Session != nil && ctx.Session.Dead {
 		return fmt.Errorf("player is dead")
 	}


### PR DESCRIPTION
Stealth previously depended partly on status-icon timers, so actors could remain visible or targetable and local actions could bypass hiding restrictions. Use the server actor options for Hiding, Cloaking, Invisible, and Chase Walk throughout rendering, picking, and action dispatch.

- Apply the documented 2008 Sakexe visibility rules: Hiding shadows for self/GM, black silhouettes through Clairvoyance, and Invisible remaining unseen.
- Enforce movement and action restrictions, including Tunnel Drive and the skills usable while Hiding; cancel pending actions when actors enter stealth.
- Suppress names, emblems, auras, carts, and falcons that would reveal hidden actors.

The executable and cloned-client references are recorded in `docs/classic-ro-client-gap-checklist.md`. The change uses existing actor state and packet formats.

Validation passed on Linux with `CGO_ENABLED=0` and `-tags nofakecgo`: `go test ./...`, `go vet ./...`, and `staticcheck ./...`. Tests cover rendering, targeting, state transitions, action packets, self/party/GM/detection viewers, PvP, and WoE.

Live visual comparison with a running 2008 client and server remains outstanding, especially Hiding/Tunnel Drive, Cloaking, Chase Walk, and detection with a second character.
