### PR TITLE
Allow independent item windows and whisper conversations

### DIFF
--- a/docs/ui-migration-todo.md
+++ b/docs/ui-migration-todo.md
@@ -69,6 +69,13 @@ Goal: migrate the remaining RO windows and dialogs to the gogpu/ui tree style:
 
 ## Completed Cross-Cutting Work
 
+- [x] Multiple window instances
+  - Item descriptions and card artwork open independently; slotted-card
+    descriptions preserve the equipment description.
+  - Whisper conversations retain separate recipients, histories, and drafts.
+  - Shared window input follows the overlay stack for dragging and Escape.
+  - See [the reference audit, ownership, and live checks](window-instances.md).
+
 - [x] Shared drag ghost overlay
   - Inventory, storage, shop, and skill drag ghosts render in the top-level game overlay, above gogpu/ui windows and below the RO cursor.
 - [x] Final UI sharpness pass

--- a/docs/window-instances.md
+++ b/docs/window-instances.md
@@ -1,0 +1,99 @@
+# Window instances
+
+Goro's overlay manager identifies individual widgets, not window types. The
+single-instance restriction came from `worldUI` owning one item description,
+one card illustration, and one whisper conversation and sharing those objects
+between all callers.
+
+## Reference audit
+
+Checked the local clones on 2026-09-13. These findings describe the checked
+implementations; they do not establish unlimited-window behavior in the
+original 2008 executable.
+
+| Window | Evidence in the cloned clients | Goro behavior |
+| --- | --- | --- |
+| Item descriptions, including slotted cards | classic-ro-client keeps a primary description and a separate slotted-card description in `lib/ui-component/src/game/item_info_window.rs`. roBrowser's `ItemInfo` and open-midgard's `WID_ITEMINFOWND` are singletons. | Independent descriptions, as requested, including different copies of the same item. Opening a slotted card preserves its equipment description. |
+| Card artwork | All three checked clones hold one artwork window: classic-ro-client's `card_illustration`, roBrowser's `CardIllustration`, open-midgard's `WID_ITEMCOLLECTIONWND`. | Independent artwork windows, as requested. This extends the checked references. |
+| Whisper conversations | roBrowser's `WhisperBox.instances` is keyed by nickname. Its `PrivateMessage.js` enables automatic popups from `20090617`; classic-ro-client uses its main chat window. | Repair the already-existing Goro popup feature: one conversation per recipient, with independent history and drafts. This is not claimed as strict 2008 parity. |
+| Books | classic-ro-client's `Windows.book_window` and roBrowser's `MakeReadBook` are singletons. | Keep one reader. Reading closes only the originating item description. |
+| Mail reader/composer | classic-ro-client's `Windows.read_mail_window` and roBrowser's `ReadMail` are singletons. | Keep the existing mail flow and its attachment/transaction state. |
+| Equipment inspection | roBrowser's `Item.js` updates `PlayerViewEquip.getUI()` with the latest response. | Keep one inspected equipment window; its item descriptions can be opened independently. |
+| Monster information / Sense | classic-ro-client's `Windows.monster_info_window`, roBrowser's `Sense`, and the later dhxj snapshot's `UI/UIMonsterInfo.cpp` hold one window. | Keep one Sense result window. |
+| Shop, storage, vending, trade, NPC dialogs | The references tie these windows to their current server interaction. | Keep each existing server interaction; do not duplicate a transaction by cloning its window. |
+| Confirmation/input dialogs | Goro already has multiple instances of the same dialog types for different purposes. | Keep their modal and server-specific lifecycle. |
+
+Reference entry points:
+
+- `~/src/classic-ro-client/client/src/ui/windows.rs`
+- `~/src/classic-ro-client/lib/ui-component/src/game/item_info_window.rs`
+- `~/src/robr/src/UI/Components/WhisperBox/WhisperBox.js`
+- `~/src/robr/src/Engine/MapEngine/PrivateMessage.js`
+- `~/src/robr/src/UI/Components/{ItemInfo,CardIllustration,MakeReadBook,Sense}/`
+- `~/src/robr/src/UI/Components/Mail/ReadMail.js`
+- `~/src/robr/src/Engine/MapEngine/Item.js`
+- `~/src/open-midgard/src/ui/UIWindowMgr.cpp`
+
+The dhxj snapshot's original `UIWindowMgr.cpp` is mostly absent and its later
+CEGUI replacements contain empty window cases. It is not sufficient evidence
+for original-client instance limits.
+
+## Ownership and input
+
+`ItemWindows` owns pointers to item descriptions and artwork plus the existing
+single book reader. Closing a description or artwork removes only that overlay;
+the collection drops closed instances. Each description holds an item snapshot.
+The inventory, equipment, cart, storage, trade, shop, vending, mail, and equipment
+inspection paths all open descriptions through this collection.
+
+`WhisperWindows` owns one conversation per case-insensitive recipient. Closing
+a conversation preserves its bounded history and draft for the current session.
+Incoming messages update the appropriate conversation without taking keyboard
+focus. Opening a recipient explicitly raises and focuses that conversation.
+
+Both collections survive map transitions and rebind callbacks without replacing
+their overlays or changing their relative stacking order. A fresh world mode
+starts with empty collections; the existing login transition clears overlays.
+
+The existing `Window` and overlay manager handle placement, dragging, focus,
+and Escape by instance. Polling consults the same overlay stack as pointer
+dispatch; HUD windows do not consume window-close Escape actions. Modal dialogs
+retain their existing cancellation rules. New coincident windows are offset and
+clamped to the screen.
+
+The 2008 whisper acknowledgement contains only a result byte. rAthena's
+`src/map/clif.cpp:clif_parse_WisMessage` answers local recipients immediately,
+but forwards remote recipients through `intif_wis_message`; replies come back
+through `src/map/intif.cpp:intif_parse_WisEnd`. NPC and channel whispers can
+return without an acknowledgement. A recipient FIFO would therefore be
+incorrect. Server feedback stays in the main chat without guessing a recipient;
+local send failures appear in their originating conversation too. No network
+queue or packet changes are required.
+
+## Verification
+
+Automated tests exercise independent item snapshots, slotted-card navigation
+and artwork buttons through UI events, individual close/rebind behavior,
+book reader reuse, overlapping-window dragging and Escape, HUD/menu behavior,
+trade/vending cancellation packets, mail/cart cleanup, on-screen placement,
+whisper focus/drafts/recipient routing, popup preferences, map transitions, and
+acknowledgements interleaved with console sends.
+
+Validation commands:
+
+```sh
+CGO_ENABLED=0 go test -tags nofakecgo ./...
+CGO_ENABLED=0 staticcheck -tags nofakecgo ./...
+```
+
+Live checks still needed:
+
+- Open several descriptions from inventory, equipment, storage, and a shop.
+  Compare two copies of an item, inspect their cards, and close them separately.
+- Drag overlapping windows; press Escape with the pointer over a different
+  window. Confirm that the visible top window closes and the map receives no click.
+- Chat with two recipients while receiving a message from a third. Check draft
+  preservation, recipient selection, popup preferences, and error feedback.
+- Warp with descriptions, artwork, and conversations open, then log out and
+  select another character. Check that map transitions preserve instances and
+  a new session starts cleanly.

--- a/game/whisper_window.go
+++ b/game/whisper_window.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (m *WorldMode) updateWhisperWindow(ctx client.Context) bool {
-	consumed := m.ui.whisperWindow.Update(ctx)
-	if action := m.ui.whisperWindow.PopAction(); action.Target != "" && action.Message != "" {
+	consumed, action := m.ui.whisperWindows.Update(ctx)
+	if action.Target != "" && action.Message != "" {
 		m.sendWhisperWindowMessage(ctx, action)
 		return true
 	}
@@ -25,18 +25,22 @@ func (m *WorldMode) sendWhisperWindowMessage(ctx client.Context, action gameui.W
 	if target == "" || message == "" {
 		return
 	}
+	conversation := m.ui.whisperWindows.Find(target)
+	if conversation == nil {
+		return
+	}
 	if ctx.Network == nil {
-		m.ui.whisperWindow.AddError(ctx, "send failed: not connected")
+		conversation.AddError(ctx, "send failed: not connected")
 		m.ui.console.AddErrorMessage("send failed: not connected")
 		return
 	}
 	if err := ctx.Network.SendWhisper(target, message); err != nil {
-		m.ui.whisperWindow.AddError(ctx, "send failed: "+err.Error())
+		conversation.AddError(ctx, "send failed: "+err.Error())
 		m.ui.console.AddErrorMessage("send failed: %s", err)
 		glog.Warnf("whisper window send failed target=%q: %v", target, err)
 		return
 	}
-	m.ui.whisperWindow.AddOutgoing(ctx, message)
+	conversation.AddOutgoing(ctx, message)
 	m.ui.console.AddBlueMessage("[ To %s ] : %s", target, message)
 }
 
@@ -46,18 +50,11 @@ func (m *WorldMode) addWhisperWindowIncoming(ctx client.Context, whisper network
 	if sender == "" || message == "" {
 		return
 	}
-	if !m.ui.whisperWindow.IsOpen() && !shouldOpenWhisperWindow(ctx.Session, sender) {
+	conversation := m.ui.whisperWindows.Find(sender)
+	if (conversation == nil || !conversation.IsOpen()) && !shouldOpenWhisperWindow(ctx.Session, sender) {
 		return
 	}
-	m.ui.whisperWindow.Open(ctx, sender)
-	m.ui.whisperWindow.AddIncoming(ctx, sender, message)
-}
-
-func (m *WorldMode) addWhisperWindowAck(ctx client.Context, ack network.WhisperAck) {
-	if ack.Result == 0 || !m.ui.whisperWindow.IsOpen() {
-		return
-	}
-	m.ui.whisperWindow.AddError(ctx, whisperAckMessage(ctx.Resources, ack))
+	m.ui.whisperWindows.AddIncoming(ctx, sender, message)
 }
 
 func shouldOpenWhisperWindow(s *session.Session, sender string) bool {

--- a/game/whisper_window_test.go
+++ b/game/whisper_window_test.go
@@ -1,0 +1,100 @@
+package game
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/uitest"
+	"github.com/gogpu/ui/widget"
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/input"
+	"github.com/kivutar/goro/network"
+	"github.com/kivutar/goro/session"
+	gameui "github.com/kivutar/goro/ui"
+)
+
+func TestWhisperWindowsRouteMessagesAndRespectRecipientSettings(t *testing.T) {
+	ctx := client.Context{Input: input.NewState(), UIManager: gameui.NewManager(), Session: &session.Session{
+		Whisper: session.WhisperSettings{Configured: true},
+	}}
+	mode := NewWorldMode()
+	alice := mode.ui.whisperWindows.Open(ctx, "Alice")
+	mode.addWhisperWindowIncoming(ctx, network.WhisperMessage{Sender: "Bob", Message: "uninvited"})
+	if mode.ui.whisperWindows.Find("Bob") != nil {
+		t.Fatal("Alice's open window bypassed Bob's popup preference")
+	}
+	mode.addWhisperWindowIncoming(ctx, network.WhisperMessage{Sender: "alice", Message: "for Alice"})
+	if !strings.Contains(whisperWindowText(alice.Widget()), "for Alice") {
+		t.Fatal("message to the existing conversation was dropped")
+	}
+	ctx.Session.Whisper.OpenStrangers = true
+	mode.addWhisperWindowIncoming(ctx, network.WhisperMessage{Sender: "Bob", Message: "for Bob"})
+	bob := mode.ui.whisperWindows.Find("Bob")
+	if bob == nil || !bob.IsOpen() || strings.Contains(whisperWindowText(alice.Widget()), "for Bob") {
+		t.Fatal("incoming conversation replaced or polluted Alice's window")
+	}
+	next := mode.nextWorldMode()
+	next.rebindPersistentUI(ctx)
+	if next.ui.whisperWindows.Find("Alice") != alice || next.ui.whisperWindows.Find("Bob") != bob {
+		t.Fatal("map change lost conversation instances")
+	}
+	if NewWorldMode().ui.whisperWindows.IsOpen() {
+		t.Fatal("fresh session inherited previous conversations")
+	}
+}
+
+func TestWhisperSendsAndUnattributedAcknowledgements(t *testing.T) {
+	netClient, server := newBotTestConnection(t, 20080910)
+	ctx := client.Context{Network: netClient, Input: input.NewState(), UIManager: gameui.NewManager()}
+	mode := NewWorldMode()
+	alice := mode.ui.whisperWindows.Open(ctx, "Alice")
+	bob := mode.ui.whisperWindows.Open(ctx, "Bob")
+	mode.sendWhisperWindowMessage(ctx, gameui.WhisperWindowAction{Target: "Alice", Message: "first"})
+	if err := client.SendChat(ctx, "/w Carol console"); err != nil {
+		t.Fatal(err)
+	}
+	mode.sendWhisperWindowMessage(ctx, gameui.WhisperWindowAction{Target: "Bob", Message: "second"})
+	readBotTestPackets(t, server, network.BuildWhisperPacket("Alice", "first"))
+	readBotTestPackets(t, server, network.BuildWhisperPacket("Carol", "console"))
+	readBotTestPackets(t, server, network.BuildWhisperPacket("Bob", "second"))
+	aliceBefore := whisperWindowText(alice.Widget())
+	bobBefore := whisperWindowText(bob.Widget())
+	// Replies carry no recipient and need not follow send order. In particular,
+	// a reply to a console send must never be assigned to an open conversation.
+	for _, result := range []byte{1, 0, 2} {
+		mode.handleNetworkPacket(ctx, network.Packet{ID: network.PacketZCAckWhisper, Data: []byte{0x98, 0x00, result}}, time.Now())
+	}
+	if whisperWindowText(alice.Widget()) != aliceBefore || whisperWindowText(bob.Widget()) != bobBefore {
+		t.Fatal("unnamed acknowledgement was assigned to a conversation")
+	}
+	netClient.Close()
+	mode.sendWhisperWindowMessage(ctx, gameui.WhisperWindowAction{Target: "Alice", Message: "offline"})
+	if !strings.Contains(whisperWindowText(alice.Widget()), "send failed") || whisperWindowText(bob.Widget()) != bobBefore {
+		t.Fatal("local send failure did not stay with its originating conversation")
+	}
+}
+
+func whisperWindowText(root widget.Widget) string {
+	if root == nil {
+		return ""
+	}
+	// Window overlays expose their updated children after drawing the damaged
+	// frame. Assert the text the player would see, after that render step.
+	ctx := widget.NewContext()
+	root.Layout(ctx, geometry.Loose(geometry.Sz(1024, 768)))
+	root.Draw(ctx, &uitest.MockCanvas{})
+	return whisperWidgetText(root)
+}
+
+func whisperWidgetText(root widget.Widget) string {
+	text := ""
+	if label, ok := root.(interface{ Content() string }); ok {
+		text = label.Content() + "\n"
+	}
+	for _, child := range root.Children() {
+		text += whisperWidgetText(child)
+	}
+	return text
+}

--- a/game/window_instances_test.go
+++ b/game/window_instances_test.go
@@ -1,0 +1,41 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/kivutar/goro/client"
+	"github.com/kivutar/goro/input"
+	"github.com/kivutar/goro/network"
+	gameui "github.com/kivutar/goro/ui"
+)
+
+func TestEscapeCancelsOnlyTopServerInteraction(t *testing.T) {
+	netClient, server := newBotTestConnection(t, 20080910)
+	manager := gameui.NewManager()
+	ctx := client.Context{Network: netClient, Input: input.NewState(), UIManager: manager, ScreenW: 1024, ScreenH: 768}
+	var trade gameui.TradeWindow
+	var vending gameui.VendingWindow
+	trade.Open(ctx, "Alice")
+	vending.OpenSetup(ctx, network.VendingOpenRequest{MaxItems: 3})
+	ctx.Input.SetKey(input.KeyEscape, true)
+	if trade.Update(ctx, nil) || !trade.IsOpen() {
+		t.Fatal("Escape canceled trade underneath the vending setup")
+	}
+	if !vending.Update(ctx, nil) || vending.KeyboardShortcutsBlocked() || !trade.IsOpen() {
+		t.Fatal("Escape did not close both vending setup windows")
+	}
+	readBotTestPackets(t, server, network.BuildCancelVendingStoreOpenPacket())
+	ctx.Input.ResetKeyboard()
+	ctx.Input.SetKey(input.KeyEscape, true)
+	if !trade.Update(ctx, nil) || trade.IsOpen() {
+		t.Fatal("Escape did not close trade after vending")
+	}
+	readBotTestPackets(t, server, network.BuildTradeCancelPacket())
+	ctx.Input.ResetKeyboard()
+	vending.ApplyOwnList(ctx, network.VendingItemList{OwnerAID: 150004})
+	ctx.Input.SetKey(input.KeyEscape, true)
+	if !vending.Update(ctx, nil) || vending.KeyboardShortcutsBlocked() || manager.TopEscapeOverlay() != nil {
+		t.Fatal("Escape left the player's vending store open")
+	}
+	readBotTestPackets(t, server, network.BuildCloseVendingStorePacket())
+}

--- a/game/world.go
+++ b/game/world.go
@@ -181,10 +181,8 @@ type worldUI struct {
 	itemPickup           gameui.ItemPickupNotification
 	shopWindow           gameui.ShopWindow
 	vendingWindow        gameui.VendingWindow
-	itemInfoWindow       gameui.ItemInfoWindow
-	cardIllustration     gameui.CardIllustrationWindow
+	itemWindows          gameui.ItemWindows
 	monsterInfoWindow    gameui.MonsterInfoWindow
-	bookWindow           gameui.BookWindow
 	identifyWindow       gameui.IdentifyWindow
 	cardWindow           gameui.CardCompositionWindow
 	makingArrow          gameui.MakingArrowWindow
@@ -209,7 +207,7 @@ type worldUI struct {
 	friendsWindow        gameui.FriendsWindow
 	guildWindow          gameui.GuildWindow
 	friendSettings       gameui.FriendSettingsWindow
-	whisperWindow        gameui.WhisperWindow
+	whisperWindows       gameui.WhisperWindows
 	chatRoomCreate       gameui.ChatRoomCreateWindow
 	chatRoom             gameui.ChatRoomWindow
 	partySettings        gameui.PartySettingsWindow
@@ -265,14 +263,14 @@ func (u *worldUI) nonConsoleKeyboardInputBlocked(ctx client.Context) bool {
 		u.mercenarySkill.IsOpen() ||
 		u.changeCartWindow.IsOpen() ||
 		u.inventoryBag.KeyboardShortcutsBlocked() ||
-		u.bookWindow.IsOpen() ||
+		u.itemWindows.KeyboardShortcutsBlocked() ||
 		u.shopWindow.KeyboardShortcutsBlocked() ||
 		u.vendingWindow.KeyboardShortcutsBlocked() ||
 		u.tradeWindow.IsOpen() ||
 		u.mailWindow.IsOpen() ||
 		u.guildWindow.KeyboardShortcutsBlocked() ||
 		u.friendSettings.IsOpen() ||
-		u.whisperWindow.IsOpen() ||
+		u.whisperWindows.IsOpen() ||
 		u.chatRoomCreate.IsOpen() ||
 		u.chatRoom.IsOpen() ||
 		u.partySettings.IsOpen() ||
@@ -572,12 +570,10 @@ func (m *WorldMode) rebindPersistentUI(ctx client.Context) {
 	}
 	m.setGuildEmblemOptions(ctx)
 	m.ui.basicMenu.Rebind(ctx, m.basicMenuCallbacks(ctx))
-	m.ui.inventoryBag.Rebind(ctx, &m.ui.itemInfoWindow)
-	m.ui.equipmentWindow.Rebind(ctx, &m.ui.itemInfoWindow, &m.ui.cartWindow, m)
-	m.ui.cartWindow.Rebind(ctx, &m.ui.itemInfoWindow)
-	m.ui.itemInfoWindow.Rebind(ctx, m)
-	m.ui.cardIllustration.Rebind(ctx)
-	m.ui.bookWindow.Rebind(ctx)
+	m.ui.inventoryBag.Rebind(ctx, &m.ui.itemWindows)
+	m.ui.equipmentWindow.Rebind(ctx, &m.ui.itemWindows, &m.ui.cartWindow, m)
+	m.ui.cartWindow.Rebind(ctx, &m.ui.itemWindows)
+	m.ui.itemWindows.Rebind(ctx, m)
 	m.ui.statsWindow.Rebind(ctx)
 	m.ui.skillWindow.Rebind(ctx, m)
 	m.ui.levelUpNotifications.Rebind(ctx)
@@ -597,7 +593,7 @@ func (m *WorldMode) rebindPersistentUI(ctx client.Context) {
 	m.ui.settingsWindow.Rebind(ctx)
 	m.ui.homunculusInfo.Rebind(ctx)
 	m.ui.mercenaryInfo.Rebind(ctx)
-	m.ui.whisperWindow.Rebind(ctx)
+	m.ui.whisperWindows.Rebind(ctx)
 	m.ui.shortcutBar.ResetOverlay(ctx)
 }
 
@@ -924,32 +920,15 @@ func (m *WorldMode) Update(ctx client.Context) (Mode, error) {
 		m.handleEscapeMenuAction(ctx)
 		return nil, nil
 	}
-	if m.ui.bookWindow.Update(ctx) {
-		return nil, nil
-	}
-	if m.ui.cardIllustration.Update(ctx) {
-		return nil, nil
-	}
 	characterWindowConsumed := m.ui.characterWindow.Update(ctx)
 	m.ui.basicMenu.FollowCharacterWindow(ctx, &m.ui.characterWindow)
 	if characterWindowConsumed {
 		return nil, nil
 	}
-	if m.ui.itemInfoWindow.Update(ctx, m) {
-		if request := m.ui.itemInfoWindow.PopCardIllustrationRequest(); request.ItemID != 0 {
-			if err := m.ui.cardIllustration.Open(ctx, request.ItemID, request.Title); err != nil {
-				m.ui.console.AddErrorMessage("Unable to display this card.")
-				glog.Warnf("card illustration open failed item=%d: %v", request.ItemID, err)
-			}
-		}
-		if request := m.ui.itemInfoWindow.PopReadBookRequest(); request.ItemID != 0 {
-			if err := m.ui.bookWindow.Open(ctx, request.ItemID, request.Title); err != nil {
-				m.ui.console.AddErrorMessage("Unable to read this book.")
-				glog.Warnf("book open failed item=%d: %v", request.ItemID, err)
-			} else {
-				m.ui.itemInfoWindow.Close()
-				m.ui.itemInfoWindow.Publish(ctx)
-			}
+	if consumed, err := m.ui.itemWindows.Update(ctx, m); consumed {
+		if err != nil {
+			m.ui.console.AddErrorMessage("Unable to display this item.")
+			glog.Warnf("item window: %v", err)
 		}
 		return nil, nil
 	}
@@ -989,34 +968,34 @@ func (m *WorldMode) Update(ctx client.Context) (Mode, error) {
 	if m.ui.shortcutBar.Update(ctx, m) {
 		return nil, nil
 	}
-	if m.ui.mailWindow.Update(ctx, &m.ui.itemInfoWindow) {
+	if m.ui.mailWindow.Update(ctx, &m.ui.itemWindows) {
 		return nil, nil
 	}
-	if m.ui.inventoryBag.Update(ctx, &m.ui.shortcutBar, &m.ui.storageWindow, &m.ui.cartWindow, &m.ui.tradeWindow, &m.ui.equipmentWindow, &m.ui.itemInfoWindow, &m.ui.mailWindow) {
+	if m.ui.inventoryBag.Update(ctx, &m.ui.shortcutBar, &m.ui.storageWindow, &m.ui.cartWindow, &m.ui.tradeWindow, &m.ui.equipmentWindow, &m.ui.itemWindows, &m.ui.mailWindow) {
 		return nil, nil
 	}
-	if m.ui.tradeWindow.Update(ctx, &m.ui.itemInfoWindow) {
+	if m.ui.tradeWindow.Update(ctx, &m.ui.itemWindows) {
 		return nil, nil
 	}
-	if m.ui.equipmentWindow.Update(ctx, &m.ui.itemInfoWindow, &m.ui.cartWindow, m) {
+	if m.ui.equipmentWindow.Update(ctx, &m.ui.itemWindows, &m.ui.cartWindow, m) {
 		return nil, nil
 	}
-	if m.ui.viewEquipWindow.Update(ctx, &m.ui.itemInfoWindow) {
+	if m.ui.viewEquipWindow.Update(ctx, &m.ui.itemWindows) {
 		return nil, nil
 	}
-	if m.ui.storageWindow.Update(ctx, &m.ui.inventoryBag, &m.ui.cartWindow, &m.ui.itemInfoWindow) {
+	if m.ui.storageWindow.Update(ctx, &m.ui.inventoryBag, &m.ui.cartWindow, &m.ui.itemWindows) {
 		return nil, nil
 	}
-	if m.ui.cartWindow.Update(ctx, &m.ui.inventoryBag, &m.ui.storageWindow, &m.ui.itemInfoWindow) {
+	if m.ui.cartWindow.Update(ctx, &m.ui.inventoryBag, &m.ui.storageWindow, &m.ui.itemWindows) {
 		return nil, nil
 	}
 	if m.ui.changeCartWindow.Update(ctx) {
 		return nil, nil
 	}
-	if m.ui.shopWindow.Update(ctx, &m.ui.itemInfoWindow) {
+	if m.ui.shopWindow.Update(ctx, &m.ui.itemWindows) {
 		return nil, nil
 	}
-	if m.ui.vendingWindow.Update(ctx, &m.ui.itemInfoWindow) {
+	if m.ui.vendingWindow.Update(ctx, &m.ui.itemWindows) {
 		return nil, nil
 	}
 	if m.ui.skillWindow.Update(ctx, &m.ui.shortcutBar, m) {
@@ -1047,7 +1026,7 @@ func (m *WorldMode) Update(ctx client.Context) (Mode, error) {
 				glog.Warnf("leave party failed: %v", err)
 			}
 		case gameui.FriendsWindowActionFriendWhisper:
-			m.ui.whisperWindow.Open(ctx, action.Friend.Name)
+			m.ui.whisperWindows.Open(ctx, action.Friend.Name)
 		case gameui.FriendsWindowActionFriendDelete:
 			m.openDeleteFriendConfirm(ctx, action.Friend)
 		case gameui.FriendsWindowActionFriendSettings:
@@ -1063,7 +1042,7 @@ func (m *WorldMode) Update(ctx client.Context) (Mode, error) {
 		case gameui.FriendsWindowActionPartyMemberInfo:
 			m.openPartyMemberInfo(ctx, action.PartyMember)
 		case gameui.FriendsWindowActionPartyMemberWhisper:
-			m.ui.whisperWindow.Open(ctx, action.PartyMember.Name)
+			m.ui.whisperWindows.Open(ctx, action.PartyMember.Name)
 		case gameui.FriendsWindowActionPartyMemberExpel:
 			m.openExpelPartyMemberConfirm(ctx, action.PartyMember)
 		}
@@ -1444,9 +1423,7 @@ func (m *WorldMode) nextWorldMode() *WorldMode {
 	next.ui.inventoryBag = m.ui.inventoryBag
 	next.ui.equipmentWindow = m.ui.equipmentWindow
 	next.ui.cartWindow = m.ui.cartWindow
-	next.ui.itemInfoWindow = m.ui.itemInfoWindow
-	next.ui.cardIllustration = m.ui.cardIllustration
-	next.ui.bookWindow = m.ui.bookWindow
+	next.ui.itemWindows = m.ui.itemWindows
 	next.ui.cardWindow = m.ui.cardWindow
 	next.ui.petEggWindow = m.ui.petEggWindow
 	next.ui.petInfoWindow = m.ui.petInfoWindow
@@ -1464,7 +1441,7 @@ func (m *WorldMode) nextWorldMode() *WorldMode {
 	next.ui.friendsWindow = m.ui.friendsWindow
 	next.ui.guildWindow = m.ui.guildWindow
 	next.ui.friendSettings = m.ui.friendSettings
-	next.ui.whisperWindow = m.ui.whisperWindow
+	next.ui.whisperWindows = m.ui.whisperWindows
 	next.ui.chatRoomCreate = m.ui.chatRoomCreate
 	next.ui.chatRoom = m.ui.chatRoom
 	next.pendingChatRoom = m.pendingChatRoom
@@ -1607,7 +1584,7 @@ func (m *WorldMode) DrawUIOverlay(ctx client.Context, screen *render.Frame) {
 	m.ui.inventoryBag.DrawTooltip(ctx, screen)
 	m.ui.equipmentWindow.DrawTooltip(ctx, screen)
 	m.ui.cartWindow.DrawTooltip(ctx, screen)
-	m.ui.itemInfoWindow.DrawTooltip(ctx, screen)
+	m.ui.itemWindows.DrawTooltip(ctx, screen)
 	m.ui.skillWindow.DrawTooltip(ctx, screen)
 	m.ui.homunculusSkill.DrawTooltip(ctx, screen)
 	m.ui.mercenarySkill.DrawTooltip(ctx, screen)

--- a/game/world_mode_session_test.go
+++ b/game/world_mode_session_test.go
@@ -230,7 +230,7 @@ func TestNextWorldModeCarriesOpenInventoryWindow(t *testing.T) {
 	if len(manager.overlays) != 1 {
 		t.Fatalf("inventory overlays after mode replacement = %d, want carried overlay", len(manager.overlays))
 	}
-	next.ui.inventoryBag.Update(ctx, &next.ui.shortcutBar, &next.ui.storageWindow, &next.ui.cartWindow, nil, &next.ui.equipmentWindow, &next.ui.itemInfoWindow)
+	next.ui.inventoryBag.Update(ctx, &next.ui.shortcutBar, &next.ui.storageWindow, &next.ui.cartWindow, nil, &next.ui.equipmentWindow, &next.ui.itemWindows)
 	if len(manager.overlays) != 1 {
 		t.Fatalf("inventory overlays after next mode update = %d, want 1", len(manager.overlays))
 	}
@@ -244,7 +244,7 @@ func TestNextWorldModeCarriesAndRebindsWhisperWindow(t *testing.T) {
 		ScreenH:   720,
 	}
 	mode := &WorldMode{}
-	mode.ui.whisperWindow.Open(ctx, "Alice")
+	mode.ui.whisperWindows.Open(ctx, "Alice")
 	manager := ctx.UIManager.(*worldModeTestUIManager)
 	if len(manager.overlays) != 1 {
 		t.Fatalf("whisper overlays before map change = %d, want 1", len(manager.overlays))
@@ -252,7 +252,7 @@ func TestNextWorldModeCarriesAndRebindsWhisperWindow(t *testing.T) {
 	previousOverlay := manager.overlays[0]
 
 	next := mode.nextWorldMode()
-	if !next.ui.whisperWindow.IsOpen() {
+	if !next.ui.whisperWindows.IsOpen() {
 		t.Fatal("next world mode did not carry open whisper window")
 	}
 	next.rebindPersistentUI(ctx)
@@ -260,11 +260,11 @@ func TestNextWorldModeCarriesAndRebindsWhisperWindow(t *testing.T) {
 	if len(manager.overlays) != 1 {
 		t.Fatalf("whisper overlays after rebind = %d, want 1", len(manager.overlays))
 	}
-	if manager.overlays[0] == previousOverlay {
-		t.Fatal("whisper overlay was not rebound")
+	if manager.overlays[0] != previousOverlay {
+		t.Fatal("whisper rebind replaced its stable overlay")
 	}
 
-	next.ui.whisperWindow.AddError(ctx, "send failed")
+	next.ui.whisperWindows.Find("Alice").AddError(ctx, "send failed")
 	if len(manager.overlays) != 1 {
 		t.Fatalf("whisper overlays after refresh = %d, want 1", len(manager.overlays))
 	}

--- a/game/world_packets.go
+++ b/game/world_packets.go
@@ -167,8 +167,9 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 	if ack, ok, err := network.ParseWhisperAck(pkt); err != nil {
 		glog.Errorf("parse whisper ack 0x%04X: %v", pkt.ID, err)
 	} else if ok {
+		// This reply has no recipient and may arrive out of send order across
+		// map servers. Keep it in the console, without guessing a conversation.
 		addWhisperAck(&m.ui.console, ctx.Resources, ack)
-		m.addWhisperWindowAck(ctx, ack)
 		return nil, false
 	}
 	if ack, ok, err := network.ParseWhisperIgnoreAck(pkt); err != nil {
@@ -561,7 +562,7 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 		glog.Debugf("cart item list items=%d", len(cartItems))
 		applyCartItemList(ctx, cartItems)
 		m.ui.cartWindow.ClampScroll(ctx.Session)
-		m.ui.cartWindow.Refresh(ctx, &m.ui.itemInfoWindow)
+		m.ui.cartWindow.Refresh(ctx, &m.ui.itemWindows)
 		return nil, false
 	}
 	if storageAmount, ok, err := network.ParseStorageAmount(pkt); err != nil {
@@ -579,7 +580,7 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 		glog.Debugf("cart amount count=%d/%d weight=%d/%d", cartAmount.Amount, cartAmount.MaxAmount, cartAmount.Weight, cartAmount.MaxWeight)
 		applyCartAmount(ctx, cartAmount)
 		m.ui.cartWindow.ClampScroll(ctx.Session)
-		m.ui.cartWindow.Refresh(ctx, &m.ui.itemInfoWindow)
+		m.ui.cartWindow.Refresh(ctx, &m.ui.itemWindows)
 		return nil, false
 	}
 	if friends, ok, err := network.ParseFriendsList(pkt); err != nil {
@@ -965,7 +966,7 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 		glog.Debugf("cart item added index=%d item=%d amount=%d", cartItem.Index, cartItem.ItemID, cartItem.Amount)
 		applyCartItemAdded(ctx, cartItem)
 		m.ui.cartWindow.ClampScroll(ctx.Session)
-		m.ui.cartWindow.Refresh(ctx, &m.ui.itemInfoWindow)
+		m.ui.cartWindow.Refresh(ctx, &m.ui.itemWindows)
 		m.ui.inventoryBag.ClampScroll(ctx.Session)
 		return nil, false
 	}
@@ -990,7 +991,7 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 	} else if ok {
 		applyStorageItemRemoved(ctx, storageItem)
 		m.ui.storageWindow.ClampScroll(ctx.Session)
-		m.ui.storageWindow.Refresh(ctx, &m.ui.itemInfoWindow)
+		m.ui.storageWindow.Refresh(ctx, &m.ui.itemWindows)
 		return nil, false
 	}
 	if cartItem, ok, err := network.ParseCartItemRemoved(pkt); err != nil {
@@ -998,7 +999,7 @@ func (m *WorldMode) handleNetworkPacket(ctx client.Context, pkt network.Packet, 
 	} else if ok {
 		applyCartItemRemoved(ctx, cartItem)
 		m.ui.cartWindow.ClampScroll(ctx.Session)
-		m.ui.cartWindow.Refresh(ctx, &m.ui.itemInfoWindow)
+		m.ui.cartWindow.Refresh(ctx, &m.ui.itemWindows)
 		return nil, false
 	}
 	if vendOpen, ok, err := network.ParseVendingOpenRequest(pkt); err != nil {

--- a/ui/basic_menu.go
+++ b/ui/basic_menu.go
@@ -58,6 +58,7 @@ func (m *BasicMenu) Update(ctx client.Context, callbacks BasicMenuCallbacks) boo
 	width, height := basicMenuSize()
 	if m.EnsureWindow(width, height) {
 		m.titleHeight = 0
+		m.CloseOnEsc = false
 	}
 	if !m.IsOpen() {
 		m.OpenAt(basicMenuX, basicMenuY, m.widgetTree())
@@ -74,6 +75,7 @@ func (m *BasicMenu) Rebind(ctx client.Context, callbacks BasicMenuCallbacks) {
 	width, height := basicMenuSize()
 	if m.EnsureWindow(width, height) {
 		m.titleHeight = 0
+		m.CloseOnEsc = false
 	}
 	m.content = nil
 	if !m.IsOpen() {
@@ -92,6 +94,7 @@ func (m *BasicMenu) FollowCharacterWindow(ctx client.Context, character *Charact
 	width, height := basicMenuSize()
 	if m.EnsureWindow(width, height) {
 		m.titleHeight = 0
+		m.CloseOnEsc = false
 	}
 	x := character.x
 	y := character.y + character.height + basicMenuFollowGap

--- a/ui/book_window.go
+++ b/ui/book_window.go
@@ -80,7 +80,9 @@ func (w *BookWindow) Rebind(ctx Context) {
 	if !w.IsOpen() {
 		return
 	}
-	w.RebindContent(ctx, w.widgetTree(ctx))
+	w.ctx = ctx
+	w.SetContent(w.widgetTree(ctx))
+	w.Publish(ctx)
 }
 
 func (w *BookWindow) widgetTree(ctx Context) widget.Widget {

--- a/ui/card_illustration_window.go
+++ b/ui/card_illustration_window.go
@@ -59,7 +59,9 @@ func (w *CardIllustrationWindow) Rebind(ctx Context) {
 	if !w.IsOpen() {
 		return
 	}
-	w.RebindContent(ctx, w.widgetTree(ctx))
+	w.ctx = ctx
+	w.SetContent(w.widgetTree(ctx))
+	w.Publish(ctx)
 }
 
 func (w *CardIllustrationWindow) widgetTree(ctx Context) widget.Widget {

--- a/ui/cart_window.go
+++ b/ui/cart_window.go
@@ -34,7 +34,7 @@ type CartWindow struct {
 	Window
 	scrollY       state.Signal[float32]
 	snapshot      uint64
-	itemInfo      *ItemInfoWindow
+	itemInfo      *ItemWindows
 	lastClickItem uint16
 	lastClickAt   time.Time
 	dragItem      session.InventoryItem
@@ -80,7 +80,7 @@ func (w *CartWindow) OpenWindow(ctx Context) {
 	w.Publish(ctx)
 }
 
-func (w *CartWindow) Update(ctx Context, inventory *InventoryBagWindow, storage *StorageWindow, itemInfo *ItemInfoWindow) bool {
+func (w *CartWindow) Update(ctx Context, inventory *InventoryBagWindow, storage *StorageWindow, itemInfo *ItemWindows) bool {
 	w.EnsureWindow(cartWindowWidth, cartWindowHeight)
 	if !w.IsOpen() || ctx.Input == nil {
 		w.hideTooltip()
@@ -190,7 +190,7 @@ func (w *CartWindow) AcceptStorageDrop(ctx Context, item session.InventoryItem, 
 	return true
 }
 
-func (w *CartWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow) widget.Widget {
+func (w *CartWindow) widgetTree(ctx Context, itemInfo *ItemWindows) widget.Widget {
 	items := sortedCartItems(ctx.Session)
 	grid := newInventoryGridWidget(inventoryGridConfig{
 		items:     items,
@@ -296,7 +296,7 @@ func (w *CartWindow) withdraw(ctx Context, item session.InventoryItem) {
 	glog.Debugf("cart withdraw requested index=%d item=%d amount=%d", item.Index, item.ItemID, amount)
 }
 
-func (w *CartWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *CartWindow) refresh(ctx Context, itemInfo *ItemWindows) {
 	w.EnsureWindow(cartWindowWidth, cartWindowHeight)
 	w.ClampScroll(ctx.Session)
 	w.snapshot = w.cartSnapshot(ctx.Session)
@@ -305,11 +305,11 @@ func (w *CartWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
 	w.Publish(ctx)
 }
 
-func (w *CartWindow) Refresh(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *CartWindow) Refresh(ctx Context, itemInfo *ItemWindows) {
 	w.refresh(ctx, itemInfo)
 }
 
-func (w *CartWindow) Rebind(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *CartWindow) Rebind(ctx Context, itemInfo *ItemWindows) {
 	w.EnsureWindow(cartWindowWidth, cartWindowHeight)
 	if !w.IsOpen() {
 		return

--- a/ui/character_window.go
+++ b/ui/character_window.go
@@ -46,6 +46,7 @@ type CharacterWindow struct {
 
 func (w *CharacterWindow) Update(ctx Context) bool {
 	w.EnsureWindow(characterWindowWidth, characterWindowHeight)
+	w.CloseOnEsc = false
 	_, basicMenuHeight := basicMenuSize()
 	w.dragBottom = basicMenuFollowGap + basicMenuHeight
 	if ctx.Session == nil {

--- a/ui/chat_room_window.go
+++ b/ui/chat_room_window.go
@@ -78,12 +78,6 @@ func (w *ChatRoomWindow) Update(ctx Context) bool {
 	if !w.IsOpen() {
 		return false
 	}
-	if ctx.Input != nil && ctx.Input.JustPressed(input.KeyEscape) {
-		// Leaving a chat room is server state, not just a local window close.
-		// Match the title-bar close button and queue the exit request.
-		w.requestLeave(ctx)
-		return true
-	}
 	if w.submitFromFocusedEnter(ctx) {
 		w.Publish(ctx)
 		return true

--- a/ui/console.go
+++ b/ui/console.go
@@ -197,6 +197,7 @@ func (c *ChatConsole) ensureWindow(ctx client.Context) {
 	key := c.renderKey(width, height)
 	if c.window.width == 0 {
 		c.window = NewWindow(width, height)
+		c.window.CloseOnEsc = false
 		c.window.titleHeight = 0
 		c.window.SetFullRedraw(true)
 	}

--- a/ui/equipment_window.go
+++ b/ui/equipment_window.go
@@ -34,7 +34,7 @@ const (
 type EquipmentWindow struct {
 	Window
 	snapshot      string
-	itemInfo      *ItemInfoWindow
+	itemInfo      *ItemWindows
 	cart          *CartWindow
 	hasCart       bool
 	hasPeco       bool
@@ -110,7 +110,7 @@ func (w *EquipmentWindow) Toggle(ctx Context) {
 	w.Publish(ctx)
 }
 
-func (w *EquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow, cart *CartWindow, assets AssetProvider) bool {
+func (w *EquipmentWindow) Update(ctx Context, itemInfo *ItemWindows, cart *CartWindow, assets AssetProvider) bool {
 	w.EnsureWindow(equipmentWindowWidth, equipmentWindowHeight)
 	if !w.IsOpen() {
 		w.hideTooltip()
@@ -142,7 +142,7 @@ func (w *EquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow, cart *Ca
 	return consumed
 }
 
-func (w *EquipmentWindow) Rebind(ctx Context, itemInfo *ItemInfoWindow, cart *CartWindow, assets AssetProvider) {
+func (w *EquipmentWindow) Rebind(ctx Context, itemInfo *ItemWindows, cart *CartWindow, assets AssetProvider) {
 	w.EnsureWindow(equipmentWindowWidth, equipmentWindowHeight)
 	if !w.IsOpen() {
 		return
@@ -159,7 +159,7 @@ func (w *EquipmentWindow) Rebind(ctx Context, itemInfo *ItemInfoWindow, cart *Ca
 	w.Publish(ctx)
 }
 
-func (w *EquipmentWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow, cart *CartWindow) widget.Widget {
+func (w *EquipmentWindow) widgetTree(ctx Context, itemInfo *ItemWindows, cart *CartWindow) widget.Widget {
 	return Win(
 		Title("Equipment"),
 		CloseButton(true),
@@ -207,7 +207,7 @@ func (w *EquipmentWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow, cart
 	)
 }
 
-func (w *EquipmentWindow) footerWidgets(ctx Context, itemInfo *ItemInfoWindow, cart *CartWindow) []widget.Widget {
+func (w *EquipmentWindow) footerWidgets(ctx Context, itemInfo *ItemWindows, cart *CartWindow) []widget.Widget {
 	children := []widget.Widget{
 		primitives.Box(
 			rotheme.Checkbox(
@@ -244,7 +244,7 @@ func (w *EquipmentWindow) footerWidgets(ctx Context, itemInfo *ItemInfoWindow, c
 	return children
 }
 
-func (w *EquipmentWindow) slotWidget(ctx Context, itemInfo *ItemInfoWindow, slot equipmentSlotDef, width int) widget.Widget {
+func (w *EquipmentWindow) slotWidget(ctx Context, itemInfo *ItemWindows, slot equipmentSlotDef, width int) widget.Widget {
 	if !equipmentSlotVisible(ctx.Session, slot) {
 		return primitives.Box().
 			Width(float32(width)).

--- a/ui/escape_menu.go
+++ b/ui/escape_menu.go
@@ -105,6 +105,9 @@ func (m *EscapeMenu) Update(ctx client.Context) bool {
 		return false
 	}
 	if ctx.Input.JustPressed(input.KeyEscape) {
+		if top := topEscapeOverlay(ctx); top != nil && top != m.published {
+			return false
+		}
 		m.Toggle(ctx)
 		return true
 	}

--- a/ui/guild_window.go
+++ b/ui/guild_window.go
@@ -196,7 +196,7 @@ func (w *GuildWindow) UpdateKeyboardInput(ctx Context) bool {
 	if ctx.Input == nil || !w.KeyboardShortcutsBlocked() {
 		return false
 	}
-	if ctx.Input.JustPressed(input.KeyEscape) {
+	if w.escapePressed(ctx) {
 		w.Close()
 		return true
 	}

--- a/ui/homunculus_skill_window.go
+++ b/ui/homunculus_skill_window.go
@@ -159,11 +159,6 @@ func (w *HomunculusSkillWindow) Update(ctx Context, shortcuts *ShortcutBar, acti
 	if w.UpdateDrag(ctx, shortcuts) {
 		return true
 	}
-	if ctx.Input.JustPressed(input.KeyEscape) {
-		w.close(ctx)
-		w.Publish(ctx)
-		return true
-	}
 	w.clampScroll(ctx)
 	snapshot := w.skillSnapshot(ctx.Session)
 	if snapshot != w.snapshot {

--- a/ui/inventory_bag_window.go
+++ b/ui/inventory_bag_window.go
@@ -66,7 +66,7 @@ type InventoryBagWindow struct {
 	tab           int
 	scrollY       state.Signal[float32]
 	snapshot      string
-	itemInfo      *ItemInfoWindow
+	itemInfo      *ItemWindows
 	lastClickItem uint16
 	lastClickAt   time.Time
 	dragItem      session.InventoryItem
@@ -101,7 +101,7 @@ func (w *InventoryBagWindow) Toggle(ctx Context) {
 	w.Publish(ctx)
 }
 
-func (w *InventoryBagWindow) Update(ctx Context, shortcuts *ShortcutBar, storage *StorageWindow, cart *CartWindow, trade *TradeWindow, equipment *EquipmentWindow, itemInfo *ItemInfoWindow, dropTargets ...InventoryDropTarget) bool {
+func (w *InventoryBagWindow) Update(ctx Context, shortcuts *ShortcutBar, storage *StorageWindow, cart *CartWindow, trade *TradeWindow, equipment *EquipmentWindow, itemInfo *ItemWindows, dropTargets ...InventoryDropTarget) bool {
 	w.EnsureWindow(inventoryBagWidth, inventoryBagHeight)
 	if !w.IsOpen() || ctx.Input == nil {
 		w.hideTooltip()
@@ -229,7 +229,7 @@ func (w *InventoryBagWindow) DrawDragGhost(screen *render.Frame, ctx Context, as
 	assets.DrawInventoryItemIcon(screen, ctx.Resources, w.dragItem, ctx.Input.MouseX-inventoryIconSize/2, ctx.Input.MouseY-inventoryIconSize/2)
 }
 
-func (w *InventoryBagWindow) Rebind(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *InventoryBagWindow) Rebind(ctx Context, itemInfo *ItemWindows) {
 	w.EnsureWindow(inventoryBagWidth, inventoryBagHeight)
 	if !w.IsOpen() {
 		return
@@ -241,7 +241,7 @@ func (w *InventoryBagWindow) PendingCardIndex() uint16 {
 	return w.pendingCard
 }
 
-func (w *InventoryBagWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow) widget.Widget {
+func (w *InventoryBagWindow) widgetTree(ctx Context, itemInfo *ItemWindows) widget.Widget {
 	items := w.tabItems(ctx.Session)
 	grid := newInventoryGridWidget(inventoryGridConfig{
 		items:     items,
@@ -312,7 +312,7 @@ func (w *InventoryBagWindow) tabColumn(ctx Context) widget.Widget {
 		Gap(-inventoryBagTabOver)
 }
 
-func (w *InventoryBagWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *InventoryBagWindow) refresh(ctx Context, itemInfo *ItemWindows) {
 	w.hideTooltip()
 	w.ClampScroll(ctx.Session)
 	w.snapshot = w.inventorySnapshot(ctx.Session)

--- a/ui/item_info_window.go
+++ b/ui/item_info_window.go
@@ -39,6 +39,7 @@ type ItemInfoWindow struct {
 	bookAvailable   bool
 	readBookRequest ItemInfoReadBookRequest
 	cardArtRequest  ItemInfoCardIllustrationRequest
+	cardInfoRequest itemInfoCardRequest
 	tooltip         tooltipState
 	slotIcons       map[string]image.Image
 	slotIconMiss    map[string]struct{}
@@ -54,6 +55,11 @@ type ItemInfoCardIllustrationRequest struct {
 	Title  string
 }
 
+type itemInfoCardRequest struct {
+	ItemID uint16
+	X, Y   int
+}
+
 func (w *ItemInfoWindow) openItem(ctx Context, item session.InventoryItem, mouseX, mouseY int) {
 	if item.ItemID == 0 {
 		return
@@ -66,6 +72,7 @@ func (w *ItemInfoWindow) openItem(ctx Context, item session.InventoryItem, mouse
 	w.bookAvailable = itemInfoShowsReadBook(ctx, item)
 	w.readBookRequest = ItemInfoReadBookRequest{}
 	w.cardArtRequest = ItemInfoCardIllustrationRequest{}
+	w.cardInfoRequest = itemInfoCardRequest{}
 	w.tooltip.Hide()
 
 	height := w.windowHeight(ctx)
@@ -286,7 +293,7 @@ func (w *ItemInfoWindow) openCard(ctx Context, cardID uint16, mouseX, mouseY int
 	if cardID == 0 {
 		return
 	}
-	w.openItem(ctx, session.InventoryItem{ItemID: cardID, Type: db.ItemTypeCard, Identified: true}, mouseX, mouseY)
+	w.cardInfoRequest = itemInfoCardRequest{ItemID: cardID, X: mouseX, Y: mouseY}
 }
 
 func (w *ItemInfoWindow) cardSlotCardID(index int) uint16 {

--- a/ui/item_window_group.go
+++ b/ui/item_window_group.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/kivutar/goro/db"
+	"github.com/kivutar/goro/render"
+	"github.com/kivutar/goro/session"
+)
+
+// ItemWindows owns independently closable descriptions and card artwork.
+// Each description is a snapshot, so inspecting another item cannot change it.
+// The book reader remains a single window.
+type ItemWindows struct {
+	descriptions  []*ItemInfoWindow
+	illustrations []*CardIllustrationWindow
+	book          BookWindow
+}
+
+func (w *ItemWindows) openItem(ctx Context, item session.InventoryItem, x, y int) {
+	if item.ItemID == 0 {
+		return
+	}
+	info := &ItemInfoWindow{}
+	info.openItem(ctx, item, x, y)
+	info.placeNew(ctx, info.x, info.y)
+	w.descriptions = append(w.descriptions, info)
+}
+
+func (w *ItemWindows) Update(ctx Context, assets AssetProvider) (bool, error) {
+	w.pruneClosed()
+	if consumed, err := w.handleRequests(ctx); consumed {
+		return true, err
+	}
+	if w.book.Update(ctx) {
+		return true, nil
+	}
+	for _, art := range w.illustrations {
+		if art.Update(ctx) {
+			return true, nil
+		}
+	}
+	for _, info := range w.descriptions {
+		if info.Update(ctx, assets) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (w *ItemWindows) handleRequests(ctx Context) (bool, error) {
+	for _, info := range w.descriptions {
+		if request := info.cardInfoRequest; request.ItemID != 0 {
+			info.cardInfoRequest = itemInfoCardRequest{}
+			w.openItem(ctx, session.InventoryItem{ItemID: request.ItemID, Type: db.ItemTypeCard, Identified: true}, request.X, request.Y)
+			return true, nil
+		}
+		if request := info.PopCardIllustrationRequest(); request.ItemID != 0 {
+			art := &CardIllustrationWindow{}
+			if err := art.Open(ctx, request.ItemID, request.Title); err != nil {
+				return true, fmt.Errorf("unable to display card: %w", err)
+			}
+			art.placeNew(ctx, info.x+ROWindowTitleHeight, info.y+ROWindowTitleHeight)
+			w.illustrations = append(w.illustrations, art)
+			return true, nil
+		}
+		if request := info.PopReadBookRequest(); request.ItemID != 0 {
+			if err := w.book.Open(ctx, request.ItemID, request.Title); err != nil {
+				return true, fmt.Errorf("unable to read book: %w", err)
+			}
+			info.Close()
+			w.book.Raise(ctx)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (w *ItemWindows) Rebind(ctx Context, assets AssetProvider) {
+	w.pruneClosed()
+	for _, info := range w.descriptions {
+		info.Rebind(ctx, assets)
+	}
+	for _, art := range w.illustrations {
+		art.Rebind(ctx)
+	}
+	w.book.Rebind(ctx)
+}
+
+func (w *ItemWindows) KeyboardShortcutsBlocked() bool { return w.book.IsOpen() }
+
+func (w *ItemWindows) DrawTooltip(ctx Context, screen *render.Frame) {
+	for _, info := range w.descriptions {
+		if info.IsOpen() {
+			info.DrawTooltip(ctx, screen)
+		}
+	}
+}
+
+func (w *ItemWindows) pruneClosed() {
+	w.descriptions = slices.DeleteFunc(w.descriptions, func(info *ItemInfoWindow) bool { return !info.IsOpen() })
+	w.illustrations = slices.DeleteFunc(w.illustrations, func(art *CardIllustrationWindow) bool { return !art.IsOpen() })
+}

--- a/ui/mail_window.go
+++ b/ui/mail_window.go
@@ -59,7 +59,7 @@ type MailWindow struct {
 	readBodyField                         *rotheme.TextAreaWidget
 	readWindow                            Window
 	ctx                                   Context
-	itemInfo                              *ItemInfoWindow
+	itemInfo                              *ItemWindows
 	inbox                                 []network.MailEntry
 	message                               *network.MailMessage
 	page                                  int
@@ -110,15 +110,12 @@ func (w *MailWindow) requestClose() {
 	w.actions = append(w.actions, MailAction{Kind: MailActionClose})
 }
 
-func (w *MailWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *MailWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 	w.ctx, w.itemInfo = ctx, itemInfo
 	if w.UpdateModal(ctx) {
 		return true
 	}
 	if w.readWindow.Update(ctx) {
-		if !w.readWindow.IsOpen() {
-			w.closeRead()
-		}
 		w.readWindow.Publish(ctx)
 		return true
 	}
@@ -126,10 +123,6 @@ func (w *MailWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
 		return false
 	}
 	consumed := w.Window.Update(ctx)
-	if !w.IsOpen() {
-		w.requestClose()
-		return true
-	}
 	w.Publish(ctx)
 	return consumed
 }
@@ -151,7 +144,7 @@ func (w *MailWindow) UpdateKeyboardInput(ctx Context) bool {
 	if !focused {
 		return false
 	}
-	if ctx.Input.JustPressed(input.KeyEscape) {
+	if w.escapePressed(ctx) {
 		w.requestClose()
 		return true
 	}

--- a/ui/manager.go
+++ b/ui/manager.go
@@ -112,11 +112,33 @@ func (m *Manager) RaiseOverlay(root widget.Widget) {
 	m.raiseOverlay(root)
 }
 
+// TopEscapeOverlay uses the same stack as drawing and pointer dispatch.
+// HUD overlays do not participate in closing windows with Escape.
+func (m *Manager) TopEscapeOverlay() widget.Widget {
+	for i := len(m.overlays) - 1; i >= 0; i-- {
+		if window, ok := m.overlays[i].(*positionedOverlay); ok && window.closeOnEsc {
+			return window
+		}
+	}
+	return nil
+}
+
 func (m *Manager) apply() {
 	m.root = newOverlayRoot(m.overlays)
 	m.root.onActivate = m.raiseOverlay
 	if m.app != nil && m.root != nil {
+		// Replacing the UI root can clear focus while an existing overlay is
+		// awaiting redraw. Preserve it if that widget still belongs to the stack.
+		ctx := windowWidgetContext(client.Context{UIApp: m.app})
+		var focused widget.Widget
+		if ctx != nil {
+			focused = ctx.FocusedWidget()
+			ctx.ReleaseFocus(focused)
+		}
 		m.app.SetUIRoot(m.root)
+		if focused != nil && overlayContainsWidget(m.root, focused) {
+			ctx.RequestFocus(focused)
+		}
 		disableRootRepaintBoundary(m.root)
 		m.root.SetNeedsRedraw(true)
 	}
@@ -220,10 +242,28 @@ func (r *overlayRoot) dispatchPositionedEvent(ctx widget.Context, e event.Event,
 			continue
 		}
 		if mouse, ok := e.(*event.MouseEvent); ok && mouse.IsPress() && overlayRaisesOnPress(child) && r.onActivate != nil {
+			if focused := ctx.FocusedWidget(); focused != nil && !overlayContainsWidget(child, focused) {
+				ctx.ReleaseFocus(focused)
+			}
 			r.onActivate(child)
 		}
 		child.Event(ctx, e)
 		return true
+	}
+	return false
+}
+
+func overlayContainsWidget(root, target widget.Widget) bool {
+	if root == target {
+		return true
+	}
+	if overlay, ok := root.(*positionedOverlay); ok {
+		return overlay.child != nil && overlayContainsWidget(overlay.child, target)
+	}
+	for _, child := range root.Children() {
+		if overlayContainsWidget(child, target) {
+			return true
+		}
 	}
 	return false
 }

--- a/ui/shop_window.go
+++ b/ui/shop_window.go
@@ -174,6 +174,9 @@ func (w *ShopWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 			w.closeDealWindow(ctx)
 			return true
 		}
+		if ctx.Input.JustPressed(input.KeyEscape) {
+			return false
+		}
 		if w.dealWindow.Update(ctx) {
 			w.dealWindow.Publish(ctx)
 		}
@@ -471,6 +474,10 @@ func (w *ShopWindow) updateBuyWindow(ctx Context, itemInfo *ItemWindows) bool {
 	if w.buyWindow.escapePressed(ctx) || w.buyCartWindow.escapePressed(ctx) {
 		w.cancel(ctx)
 		return true
+	}
+	// A lower shop must not consume another window's Escape through hover.
+	if ctx.Input.JustPressed(input.KeyEscape) {
+		return false
 	}
 	if w.handleBuyPointer(ctx, itemInfo) {
 		return true

--- a/ui/shop_window.go
+++ b/ui/shop_window.go
@@ -162,7 +162,7 @@ func (w *ShopWindow) ApplyResult(ctx Context, result network.ShopResult) {
 	glog.Warnf("shop sell failed result=%d", result.Result)
 }
 
-func (w *ShopWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *ShopWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 	if ctx.Input == nil {
 		return false
 	}
@@ -170,7 +170,7 @@ func (w *ShopWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
 		return true
 	}
 	if w.dealWindow.IsOpen() {
-		if ctx.Input.JustPressed(input.KeyEscape) {
+		if w.dealWindow.escapePressed(ctx) {
 			w.closeDealWindow(ctx)
 			return true
 		}
@@ -462,13 +462,13 @@ func (w *ShopWindow) ensureBuyCartScrollSignal() state.Signal[float32] {
 	return w.buyCartScrollY
 }
 
-func (w *ShopWindow) updateBuyWindow(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *ShopWindow) updateBuyWindow(ctx Context, itemInfo *ItemWindows) bool {
 	w.ensureBuyWindow()
 	if !w.buyWindow.IsOpen() || !w.buyCartWindow.IsOpen() {
 		w.openBuyWindow(ctx)
 	}
 	w.x, w.y = w.buyWindow.x, w.buyWindow.y
-	if ctx.Input.JustPressed(input.KeyEscape) {
+	if w.buyWindow.escapePressed(ctx) || w.buyCartWindow.escapePressed(ctx) {
 		w.cancel(ctx)
 		return true
 	}
@@ -491,7 +491,7 @@ func (w *ShopWindow) updateBuyWindow(ctx Context, itemInfo *ItemInfoWindow) bool
 	return consumed || inside
 }
 
-func (w *ShopWindow) handleBuyPointer(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *ShopWindow) handleBuyPointer(ctx Context, itemInfo *ItemWindows) bool {
 	if ctx.Input.MouseJustPressed(input.MouseButtonRight) {
 		if item, ok := w.shopItemAt(ctx, ctx.Input.MouseX, ctx.Input.MouseY); ok {
 			if itemInfo != nil {

--- a/ui/skill_window.go
+++ b/ui/skill_window.go
@@ -138,11 +138,6 @@ func (w *SkillWindow) Update(ctx Context, shortcuts *ShortcutBar, actions GameAc
 	if w.UpdateDrag(ctx, shortcuts) {
 		return true
 	}
-	if ctx.Input.JustPressed(input.KeyEscape) {
-		w.close(ctx)
-		w.Publish(ctx)
-		return true
-	}
 	snapshot := w.skillSnapshot(ctx.Session)
 	w.ensureSkillViewForSnapshot(ctx, snapshot)
 	if snapshot != w.snapshot {

--- a/ui/storage_window.go
+++ b/ui/storage_window.go
@@ -40,7 +40,7 @@ type StorageWindow struct {
 	selectedRow         int
 	selectedRowSignal   state.Signal[int]
 	snapshot            uint64
-	itemInfo            *ItemInfoWindow
+	itemInfo            *ItemWindows
 	lastClickItem       uint16
 	lastClickAt         time.Time
 	dragItem            session.InventoryItem
@@ -84,7 +84,7 @@ func (w *StorageWindow) OpenWindow(ctx Context) {
 	w.Publish(ctx)
 }
 
-func (w *StorageWindow) Update(ctx Context, inventory *InventoryBagWindow, cart *CartWindow, itemInfo *ItemInfoWindow) bool {
+func (w *StorageWindow) Update(ctx Context, inventory *InventoryBagWindow, cart *CartWindow, itemInfo *ItemWindows) bool {
 	w.EnsureWindow(storageWindowWidth, storageWindowHeight)
 	if !w.IsOpen() || ctx.Input == nil {
 		return false
@@ -96,11 +96,6 @@ func (w *StorageWindow) Update(ctx Context, inventory *InventoryBagWindow, cart 
 		return false
 	}
 	if w.UpdateDrag(ctx, inventory, cart) {
-		return true
-	}
-	if ctx.Input.JustPressed(input.KeyEscape) {
-		w.close(ctx)
-		w.Publish(ctx)
 		return true
 	}
 	snapshot := w.storageSnapshot(ctx.Session)
@@ -198,7 +193,7 @@ func (w *StorageWindow) AcceptCartDrop(ctx Context, item session.InventoryItem, 
 	return true
 }
 
-func (w *StorageWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow) widget.Widget {
+func (w *StorageWindow) widgetTree(ctx Context, itemInfo *ItemWindows) widget.Widget {
 	return Win(
 		Title("Storage"),
 		CloseButton(true),
@@ -293,7 +288,7 @@ func (w *StorageWindow) tabColumn(ctx Context) widget.Widget {
 		Gap(-storageTabOver)
 }
 
-func (w *StorageWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *StorageWindow) refresh(ctx Context, itemInfo *ItemWindows) {
 	w.updateCategoryCounts(ctx.Session)
 	w.ClampScroll(ctx.Session)
 	w.snapshot = w.storageSnapshot(ctx.Session)
@@ -302,11 +297,11 @@ func (w *StorageWindow) refresh(ctx Context, itemInfo *ItemInfoWindow) {
 	w.Publish(ctx)
 }
 
-func (w *StorageWindow) Refresh(ctx Context, itemInfo *ItemInfoWindow) {
+func (w *StorageWindow) Refresh(ctx Context, itemInfo *ItemWindows) {
 	w.refresh(ctx, itemInfo)
 }
 
-func (w *StorageWindow) handlePointer(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *StorageWindow) handlePointer(ctx Context, itemInfo *ItemWindows) bool {
 	if ctx.Input.MouseJustPressed(input.MouseButtonRight) {
 		item, _, ok := w.itemAt(ctx.Session, ctx.Input.MouseX, ctx.Input.MouseY)
 		if !ok {

--- a/ui/trade_window.go
+++ b/ui/trade_window.go
@@ -70,7 +70,7 @@ func (w *TradeWindow) Open(ctx Context, partnerName string) {
 	w.Publish(ctx)
 }
 
-func (w *TradeWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *TradeWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 	w.EnsureWindow(tradeWindowW, tradeWindowH)
 	if !w.IsOpen() || ctx.Input == nil {
 		return false

--- a/ui/vending_window.go
+++ b/ui/vending_window.go
@@ -157,15 +157,20 @@ func (w *VendingWindow) ApplySoldItem(ctx Context, sold network.VendingSoldItem)
 	w.refresh(ctx)
 }
 
-func (w *VendingWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *VendingWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 	if ctx.Input == nil || w.mode == vendingModeNone {
 		return false
 	}
-	if w.leftWindow.Update(ctx) {
+	consumed := w.leftWindow.Update(ctx)
+	if consumed {
 		w.leftWindow.Publish(ctx)
 	}
 	if w.rightWindow.Update(ctx) {
+		consumed = true
 		w.rightWindow.Publish(ctx)
+	}
+	if w.mode == vendingModeNone {
+		return consumed
 	}
 	if w.handlePointer(ctx, itemInfo) {
 		return true
@@ -173,7 +178,7 @@ func (w *VendingWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
 	inside := w.inside(ctx.Input.MouseX, ctx.Input.MouseY)
 	w.leftWindow.Publish(ctx)
 	w.rightWindow.Publish(ctx)
-	return inside
+	return consumed || inside
 }
 
 func (w *VendingWindow) KeyboardShortcutsBlocked() bool {
@@ -514,7 +519,7 @@ func (w *VendingWindow) syncPriceInput() {
 	w.priceField = nil
 }
 
-func (w *VendingWindow) handlePointer(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *VendingWindow) handlePointer(ctx Context, itemInfo *ItemWindows) bool {
 	if ctx.Input == nil {
 		return false
 	}

--- a/ui/vending_window.go
+++ b/ui/vending_window.go
@@ -169,7 +169,8 @@ func (w *VendingWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 		consumed = true
 		w.rightWindow.Publish(ctx)
 	}
-	if w.mode == vendingModeNone {
+	// Preserve the shared windows' Escape result before checking pointer hover.
+	if w.mode == vendingModeNone || ctx.Input.JustPressed(input.KeyEscape) {
 		return consumed
 	}
 	if w.handlePointer(ctx, itemInfo) {

--- a/ui/view_equipment_window.go
+++ b/ui/view_equipment_window.go
@@ -16,7 +16,7 @@ type ViewEquipmentWindow struct {
 	title    string
 	items    []session.InventoryItem
 	preview  image.Image
-	itemInfo *ItemInfoWindow
+	itemInfo *ItemWindows
 	icons    map[equipmentItemIconKey]image.Image
 	iconMiss map[equipmentItemIconKey]struct{}
 }
@@ -50,7 +50,7 @@ func (w *ViewEquipmentWindow) Open(ctx Context, view network.ViewedEquipment, as
 	w.Publish(ctx)
 }
 
-func (w *ViewEquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool {
+func (w *ViewEquipmentWindow) Update(ctx Context, itemInfo *ItemWindows) bool {
 	w.EnsureWindow(equipmentWindowWidth, equipmentWindowHeight-ROWindowFooterHeight)
 	if !w.IsOpen() {
 		return false
@@ -64,7 +64,7 @@ func (w *ViewEquipmentWindow) Update(ctx Context, itemInfo *ItemInfoWindow) bool
 	return consumed
 }
 
-func (w *ViewEquipmentWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow) widget.Widget {
+func (w *ViewEquipmentWindow) widgetTree(ctx Context, itemInfo *ItemWindows) widget.Widget {
 	return Win(
 		Title(w.title),
 		CloseButton(true),
@@ -111,7 +111,7 @@ func (w *ViewEquipmentWindow) widgetTree(ctx Context, itemInfo *ItemInfoWindow) 
 	)
 }
 
-func (w *ViewEquipmentWindow) slotWidget(ctx Context, itemInfo *ItemInfoWindow, slot equipmentSlotDef, width int) widget.Widget {
+func (w *ViewEquipmentWindow) slotWidget(ctx Context, itemInfo *ItemWindows, slot equipmentSlotDef, width int) widget.Widget {
 	item, hasItem := w.itemForSlot(slot.location)
 	return newEquipmentSlotWidget(equipmentSlotWidgetConfig{
 		slot:    slot,

--- a/ui/whisper_window.go
+++ b/ui/whisper_window.go
@@ -42,6 +42,11 @@ type WhisperWindow struct {
 }
 
 func (w *WhisperWindow) Open(ctx Context, target string) {
+	w.open(ctx, target)
+	w.focusInput()
+}
+
+func (w *WhisperWindow) open(ctx Context, target string) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return
@@ -57,7 +62,6 @@ func (w *WhisperWindow) Open(ctx Context, target string) {
 		w.inputField = nil
 	}
 	w.Window.Open(ctx, w.widgetTree(ctx))
-	w.focusInput()
 	w.Publish(ctx)
 }
 
@@ -85,10 +89,14 @@ func (w *WhisperWindow) Rebind(ctx Context) {
 		return
 	}
 	w.ctx = ctx
+	focused := w.inputField != nil && w.inputField.IsFocused()
+	releaseWindowFocus(ctx, w.content)
 	w.inputField = nil
-	content := w.widgetTree(ctx)
-	w.focusInput()
-	w.RebindContent(ctx, content)
+	w.SetContent(w.widgetTree(ctx))
+	w.Publish(ctx)
+	if focused {
+		w.focusInput()
+	}
 }
 
 func (w *WhisperWindow) PopAction() WhisperWindowAction {
@@ -203,7 +211,6 @@ func (w *WhisperWindow) inputWidget(ctx Context) *textfield.Widget {
 		textfield.MaxLength(100),
 		textfield.Placeholder("Message"),
 	)
-	w.focusInput()
 	return w.inputField
 }
 
@@ -234,13 +241,16 @@ func (w *WhisperWindow) submitFromFocusedEnter(ctx Context) bool {
 
 func (w *WhisperWindow) refresh(ctx Context) {
 	w.SetContent(w.widgetTree(ctx))
-	w.focusInput()
 	w.Publish(ctx)
 }
 
 func (w *WhisperWindow) focusInput() {
 	if w.inputField != nil {
-		w.inputField.SetFocused(true)
+		if ctx := windowWidgetContext(w.ctx); ctx != nil {
+			ctx.RequestFocus(w.inputField)
+		} else {
+			w.inputField.SetFocused(true)
+		}
 	}
 }
 

--- a/ui/whisper_window_group.go
+++ b/ui/whisper_window_group.go
@@ -1,0 +1,84 @@
+package ui
+
+import "strings"
+
+// WhisperWindows keeps a conversation and draft per recipient for the session.
+// Closing a window hides the conversation; opening it again restores it.
+type WhisperWindows struct {
+	conversations []*WhisperWindow
+}
+
+func (w *WhisperWindows) Find(target string) *WhisperWindow {
+	for _, conversation := range w.conversations {
+		if strings.EqualFold(conversation.target, strings.TrimSpace(target)) {
+			return conversation
+		}
+	}
+	return nil
+}
+
+func (w *WhisperWindows) open(ctx Context, target string) *WhisperWindow {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil
+	}
+	conversation := w.Find(target)
+	if conversation == nil {
+		conversation = &WhisperWindow{}
+		w.conversations = append(w.conversations, conversation)
+	}
+	if !conversation.IsOpen() {
+		conversation.open(ctx, target)
+	}
+	return conversation
+}
+
+func (w *WhisperWindows) Open(ctx Context, target string) *WhisperWindow {
+	conversation := w.open(ctx, target)
+	if conversation != nil {
+		conversation.Raise(ctx)
+		conversation.focusInput()
+	}
+	return conversation
+}
+
+func (w *WhisperWindows) AddIncoming(ctx Context, sender, message string) {
+	if conversation := w.open(ctx, sender); conversation != nil {
+		conversation.AddIncoming(ctx, sender, message)
+	}
+}
+
+func (w *WhisperWindows) IsOpen() bool {
+	for _, conversation := range w.conversations {
+		if conversation.IsOpen() {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *WhisperWindows) Update(ctx Context) (bool, WhisperWindowAction) {
+	// Widget callbacks run before world input. Drain sends independently of
+	// which conversation happens to be under the pointer this frame.
+	for _, conversation := range w.conversations {
+		if conversation.IsOpen() {
+			conversation.submitFromFocusedEnter(ctx)
+		}
+		if action := conversation.PopAction(); action.Target != "" {
+			return true, action
+		}
+	}
+	for _, conversation := range w.conversations {
+		consumed := conversation.Update(ctx)
+		if consumed {
+			return true, WhisperWindowAction{}
+		}
+	}
+	return false, WhisperWindowAction{}
+}
+
+func (w *WhisperWindows) Rebind(ctx Context) {
+	for _, conversation := range w.conversations {
+		conversation.Rebind(ctx)
+	}
+}

--- a/ui/window.go
+++ b/ui/window.go
@@ -31,6 +31,13 @@ type windowTitleButton struct {
 	onClick func()
 }
 
+// windowFrame retains the title-bar close action for keyboard closing too.
+// This preserves each window's cleanup and server cancellation behavior.
+type windowFrame struct {
+	*primitives.BoxWidget
+	onClose func()
+}
+
 const (
 	ROWindowTitleHeight   = 28
 	ROWindowFooterHeight  = 42
@@ -100,13 +107,17 @@ func Win(options ...WindowOption) widget.Widget {
 	if cfg.background != nil {
 		background = *cfg.background
 	}
-	return primitives.Box(children...).
+	box := primitives.Box(children...).
 		CrossAlign(primitives.CrossAxisStretch).
 		Width(cfg.width).
 		Height(cfg.height).
 		Background(background).
 		BorderStyle(1, rotheme.Default.Colors.WindowBorder).
 		Rounded(cfg.radius)
+	if cfg.onClose == nil {
+		return box
+	}
+	return &windowFrame{BoxWidget: box, onClose: cfg.onClose}
 }
 
 func windowBodyColor(opacity float32) widget.Color {
@@ -256,6 +267,7 @@ func (w *Window) EnsureWindow(width, height int) bool {
 
 func (w *Window) Close() {
 	w.cancelDragLayer(w.ctx)
+	releaseWindowFocus(w.ctx, w.content)
 	w.setOpacity(1)
 	w.open = false
 	w.dragging = false
@@ -422,17 +434,28 @@ func (w *Window) Update(ctx client.Context) bool {
 		w.endDragLayer(ctx)
 		return true
 	}
-	if w.CloseOnEsc && ctx.Input.JustPressed(input.KeyEscape) {
-		w.Close()
+	if ctx.Input.JustPressed(input.KeyEscape) {
+		if !w.CloseOnEsc || !w.escapePressed(ctx) {
+			return false
+		}
+		if frame, ok := w.content.(*windowFrame); ok && frame.onClose != nil {
+			frame.onClose()
+		} else {
+			w.Close()
+		}
 		return true
 	}
 	inside := pointInRect(ctx.Input.MouseX, ctx.Input.MouseY, w.x, w.y, w.width, w.height)
+	if manager, ok := ctx.UIManager.(interface{ OverlayAt(int, int) widget.Widget }); ok && w.published != nil {
+		inside = manager.OverlayAt(ctx.Input.MouseX, ctx.Input.MouseY) == w.published
+	}
 	if !ctx.Input.MouseJustPressed(input.MouseButtonLeft) {
 		return inside
 	}
 	if !inside {
 		return false
 	}
+	w.Raise(ctx)
 	if pointInRect(ctx.Input.MouseX, ctx.Input.MouseY, w.x, w.y, w.width, w.titleHeight) {
 		if w.titleButtonHit(ctx.Input.MouseX, ctx.Input.MouseY) {
 			return true
@@ -452,10 +475,42 @@ func (w *Window) ensurePosition(ctx client.Context) {
 		return
 	}
 	screenW, screenH := ctx.ScreenSize()
-	w.x = maxInt(windowScreenMargin, (screenW-w.width)/2)
-	w.y = maxInt(windowScreenMargin, (screenH-w.height)/2)
+	w.placeNew(ctx, (screenW-w.width)/2, (screenH-w.height)/2)
+}
+
+// placeNew keeps a new window on screen and offsets coincident title bars so
+// opening another instance leaves the previous instance accessible.
+func (w *Window) placeNew(ctx client.Context, x, y int) {
+	screenW, screenH := ctx.ScreenSize()
+	maxX := maxInt(windowScreenMargin, screenW-w.width-windowScreenMargin)
+	maxY := maxInt(windowScreenMargin, screenH-w.height-windowScreenMargin)
+	x = clampWindowInt(x, windowScreenMargin, maxX)
+	y = clampWindowInt(y, windowScreenMargin, maxY)
+	if manager, ok := ctx.UIManager.(*Manager); ok {
+		for attempts := 0; attempts < len(manager.overlays); attempts++ {
+			occupied := false
+			for _, root := range manager.overlays {
+				other, ok := root.(*positionedOverlay)
+				if ok && root != w.placed && other.raiseOnPress && other.x == x && other.y == y {
+					occupied = true
+					break
+				}
+			}
+			if !occupied {
+				break
+			}
+			x += ROWindowTitleHeight
+			y += ROWindowTitleHeight
+			if x > maxX {
+				x = windowScreenMargin
+			}
+			if y > maxY {
+				y = windowScreenMargin
+			}
+		}
+	}
 	w.positioned = true
-	w.placed = nil
+	w.setPosition(ctx, x, y)
 }
 
 func (w *Window) setOpacity(opacity float32) {
@@ -464,7 +519,11 @@ func (w *Window) setOpacity(opacity float32) {
 	if w.titleHeight <= 0 {
 		return
 	}
-	if box, ok := w.content.(*primitives.BoxWidget); ok {
+	box, _ := w.content.(*primitives.BoxWidget)
+	if frame, ok := w.content.(*windowFrame); ok {
+		box = frame.BoxWidget
+	}
+	if box != nil {
 		background := windowBodyColor(opacity)
 		if w.background != nil {
 			background = *w.background
@@ -496,7 +555,38 @@ func (w *Window) Widget() widget.Widget {
 	} else if overlay, ok := w.placed.(*positionedOverlay); ok {
 		overlay.setFrame(w.x, w.y, w.width, w.height)
 	}
+	w.positionedOverlay().closeOnEsc = w.CloseOnEsc
 	return w.placed
+}
+
+func topEscapeOverlay(ctx client.Context) widget.Widget {
+	if manager, ok := ctx.UIManager.(interface{ TopEscapeOverlay() widget.Widget }); ok {
+		return manager.TopEscapeOverlay()
+	}
+	return nil
+}
+
+func (w *Window) escapePressed(ctx client.Context) bool {
+	if ctx.Input == nil || !ctx.Input.JustPressed(input.KeyEscape) {
+		return false
+	}
+	top := topEscapeOverlay(ctx)
+	return top == nil || top == w.published
+}
+
+func releaseWindowFocus(ctx client.Context, root widget.Widget) {
+	if root == nil {
+		return
+	}
+	if focus, ok := root.(interface{ SetFocused(bool) }); ok {
+		if wc := windowWidgetContext(ctx); wc != nil {
+			wc.ReleaseFocus(root)
+		}
+		focus.SetFocused(false)
+	}
+	for _, child := range root.Children() {
+		releaseWindowFocus(ctx, child)
+	}
 }
 
 func (w *Window) setPosition(ctx client.Context, x, y int) {
@@ -713,6 +803,7 @@ type positionedOverlay struct {
 	hasDamage     bool
 	hidden        bool
 	raiseOnPress  bool
+	closeOnEsc    bool
 }
 
 func (w *positionedOverlay) setFrame(x, y, width, height int) geometry.Rect {

--- a/ui/window_instances_test.go
+++ b/ui/window_instances_test.go
@@ -1,0 +1,293 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	uiapp "github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/ui/uitest"
+	"github.com/gogpu/ui/widget"
+	"github.com/kivutar/goro/db"
+	"github.com/kivutar/goro/input"
+	"github.com/kivutar/goro/res"
+	"github.com/kivutar/goro/session"
+)
+
+type instanceTestApp struct{ basicMenuTestApp }
+
+func (a instanceTestApp) WidgetContext() widget.Context { return a.app.Window().Context() }
+
+func newWindowInstanceTest() (Context, *Manager, *uiapp.App) {
+	app := uiapp.New()
+	bridge := instanceTestApp{basicMenuTestApp{app: app}}
+	manager := NewManager()
+	manager.SetUIApp(bridge)
+	return Context{UIApp: bridge, UIManager: manager, Input: input.NewState(), ScreenW: 1024, ScreenH: 768}, manager, app
+}
+
+func TestItemDescriptionsAndCardArtworkAreIndependent(t *testing.T) {
+	ctx, manager, app := newWindowInstanceTest()
+	ctx.Resources = cardIllustrationTestManager(t)
+	var windows ItemWindows
+	item := session.InventoryItem{ItemID: 2607, Type: db.ItemTypeArmor, Location: db.EquipAccessory1, Equip: true, Identified: true, Refine: 3, Cards: [4]uint16{4001}}
+	windows.openItem(ctx, item, 100, 100)
+	item.Refine = 7
+	windows.openItem(ctx, item, 100, 100)
+	first, second := windows.descriptions[0], windows.descriptions[1]
+	if first == second || first.item.Refine != 3 || second.item.Refine != 7 || len(manager.overlays) != 2 {
+		t.Fatal("descriptions did not retain independent item snapshots")
+	}
+	if first.x == second.x && first.y == second.y {
+		t.Fatal("new description completely covered the previous title bar")
+	}
+
+	first.Raise(ctx)
+	app.Frame()
+	app.Window().DrawTo(&uitest.MockCanvas{})
+	slot := findInstanceCardSlot(first.content)
+	if slot == nil {
+		t.Fatal("slotted equipment has no card widget")
+	}
+	p := slot.ScreenBounds().Center()
+	app.Window().HandleEvent(event.NewMouseEvent(event.MousePress, event.ButtonRight, event.ButtonStateRight, p, p, event.ModNone))
+	app.Window().HandleEvent(event.NewMouseEvent(event.MouseRelease, event.ButtonRight, 0, p, p, event.ModNone))
+	if consumed, err := windows.Update(ctx, nil); !consumed || err != nil {
+		t.Fatalf("opening slotted card: consumed=%t err=%v", consumed, err)
+	}
+	if len(windows.descriptions) != 3 || first.item.Refine != 3 || first.item.ItemID != 2607 {
+		t.Fatal("opening a slotted card replaced the equipment description")
+	}
+	card := windows.descriptions[2]
+	if card.item.ItemID != 4001 {
+		t.Fatalf("card description item = %d", card.item.ItemID)
+	}
+	for range 2 {
+		card.Raise(ctx)
+		app.Frame()
+		app.Window().DrawTo(&uitest.MockCanvas{})
+		x := float32(card.x + ROWindowFooterPadding + 20)
+		y := float32(card.y + card.height - ROWindowFooterHeight/2)
+		app.Window().HandleEvent(uitest.Click(x, y))
+		app.Window().HandleEvent(uitest.Release(x, y))
+		if consumed, err := windows.Update(ctx, nil); !consumed || err != nil {
+			t.Fatalf("opening card artwork: consumed=%t err=%v", consumed, err)
+		}
+	}
+	if len(windows.illustrations) != 2 || len(manager.overlays) != 5 {
+		t.Fatalf("artwork instances=%d overlays=%d", len(windows.illustrations), len(manager.overlays))
+	}
+	art := windows.illustrations[0]
+	art.Close()
+	first.Close()
+	windows.Update(ctx, nil)
+	if len(windows.descriptions) != 2 || len(windows.illustrations) != 1 || len(manager.overlays) != 3 {
+		t.Fatal("closing instances did not remove only those instances")
+	}
+	before := append([]widget.Widget(nil), manager.overlays...)
+	windows.Rebind(ctx, nil)
+	for i, root := range before {
+		if manager.overlays[i] != root {
+			t.Fatal("rebinding changed window identity or stacking order")
+		}
+	}
+}
+
+func findInstanceCardSlot(root widget.Widget) *itemInfoCardSlotWidget {
+	if slot, ok := root.(*itemInfoCardSlotWidget); ok && slot.cardID != 0 {
+		return slot
+	}
+	for _, child := range root.Children() {
+		if slot := findInstanceCardSlot(child); slot != nil {
+			return slot
+		}
+	}
+	return nil
+}
+
+func TestReadingClosesOnlyOriginatingDescriptionAndRaisesReader(t *testing.T) {
+	ctx, manager, app := newWindowInstanceTest()
+	root := t.TempDir()
+	path := filepath.Join(root, "data", "book", "7277.txt")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("Book contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx.Resources = &res.Manager{Root: root}
+	var windows ItemWindows
+	if err := windows.book.Open(ctx, 7277, "Already open book"); err != nil {
+		t.Fatal(err)
+	}
+	reader := windows.book.published
+	windows.openItem(ctx, session.InventoryItem{ItemID: 501, Identified: true}, 100, 100)
+	other := windows.descriptions[0]
+	windows.openItem(ctx, session.InventoryItem{ItemID: 7277, Identified: true}, 100, 100)
+	description := windows.descriptions[1]
+	app.Frame()
+	app.Window().DrawTo(&uitest.MockCanvas{})
+	x := float32(description.x + ROWindowFooterPadding + 20)
+	y := float32(description.y + description.height - ROWindowFooterHeight/2)
+	app.Window().HandleEvent(uitest.Click(x, y))
+	app.Window().HandleEvent(uitest.Release(x, y))
+	if consumed, err := windows.Update(ctx, nil); !consumed || err != nil {
+		t.Fatalf("reading book: consumed=%t err=%v", consumed, err)
+	}
+	if description.IsOpen() || !other.IsOpen() || !windows.book.IsOpen() || windows.book.published != reader || manager.TopEscapeOverlay() != reader || len(manager.overlays) != 2 {
+		t.Fatal("reading replaced an unrelated description or failed to raise the existing reader")
+	}
+}
+
+func TestWindowPollingRespectsStackingAndEscape(t *testing.T) {
+	ctx, manager, app := newWindowInstanceTest()
+	lower, upper := NewWindow(200, 150), NewWindow(200, 150)
+	lower.OpenAt(100, 100, primitives.Box())
+	upper.OpenAt(130, 110, primitives.Box())
+	lower.Publish(ctx)
+	upper.Publish(ctx)
+	app.Frame()
+	app.Window().DrawTo(&uitest.MockCanvas{})
+	ctx.Input.SetMousePosition(140, 115)
+	ctx.Input.SetMouseButton(input.MouseButtonLeft, true)
+	if lower.Update(ctx) || lower.dragging {
+		t.Fatal("lower window intercepted a drag on the visible window")
+	}
+	if !upper.Update(ctx) || !upper.dragging {
+		t.Fatal("visible window did not start dragging")
+	}
+	ctx.Input.SetMouseButton(input.MouseButtonLeft, false)
+	ctx.Input.EndFrame()
+	upper.Update(ctx)
+
+	lower.Raise(ctx)
+	ctx.Input.SetMousePosition(150, 140) // Over both windows while closing the raised one.
+	ctx.Input.SetKey(input.KeyEscape, true)
+	var menu EscapeMenu
+	if menu.Update(ctx) || upper.Update(ctx) {
+		t.Fatal("Escape was intercepted before reaching the top window")
+	}
+	if !lower.Update(ctx) || lower.IsOpen() || !upper.IsOpen() {
+		t.Fatal("Escape did not close only the top window")
+	}
+	if manager.TopEscapeOverlay() != upper.published {
+		t.Fatal("closed window remained in the Escape stack")
+	}
+}
+
+func TestHUDDoesNotPreventOpeningEscapeMenu(t *testing.T) {
+	ctx, _, _ := newWindowInstanceTest()
+	ctx.Session = &session.Session{}
+	var character CharacterWindow
+	var basic BasicMenu
+	var console ChatConsole
+	character.Update(ctx)
+	basic.Update(ctx, BasicMenuCallbacks{})
+	console.Publish(ctx)
+	ctx.Input.SetKey(input.KeyEscape, true)
+	var menu EscapeMenu
+	if !menu.Update(ctx) || !menu.IsOpen() || !character.IsOpen() || !basic.IsOpen() {
+		t.Fatal("HUD windows consumed Escape before the menu could open")
+	}
+}
+
+func TestEscapeRunsWindowCleanupOnce(t *testing.T) {
+	ctx, manager, _ := newWindowInstanceTest()
+	ctx.Session = &session.Session{Selected: session.Character{ID: 150004, Option: inventoryBagCartOptionMask}}
+	var cart CartWindow
+	cart.OpenWindow(ctx)
+	ctx.Input.SetKey(input.KeyEscape, true)
+	if !cart.Update(ctx, nil, nil, nil) || cart.IsOpen() || ctx.Session.Cart.Open {
+		t.Fatal("Escape bypassed the cart's close action")
+	}
+	ctx.Input.ResetKeyboard()
+	var mail MailWindow
+	mail.Open(ctx, nil)
+	ctx.Input.SetKey(input.KeyEscape, true)
+	if !mail.Update(ctx, nil) || mail.IsOpen() {
+		t.Fatal("Escape did not close the mailbox")
+	}
+	if action := mail.PopAction(); action.Kind != MailActionClose {
+		t.Fatalf("mail close action = %+v", action)
+	}
+	if action := mail.PopAction(); action.Kind != MailActionNone {
+		t.Fatalf("mail close action ran more than once: %+v", action)
+	}
+	if manager.TopEscapeOverlay() != nil {
+		t.Fatal("closed transaction window remained in the Escape stack")
+	}
+}
+
+func TestWhisperInstancesKeepDraftsFocusAndRecipients(t *testing.T) {
+	ctx, manager, app := newWindowInstanceTest()
+	var windows WhisperWindows
+	alice := windows.Open(ctx, "Alice")
+	app.Window().HandleEvent(uitest.KeyType(event.KeyA, 'a', event.ModNone))
+	bob := windows.Open(ctx, "Bob")
+	app.Window().HandleEvent(uitest.KeyType(event.KeyB, 'b', event.ModNone))
+	if alice.input != "a" || bob.input != "b" || alice.inputField.IsFocused() || !bob.inputField.IsFocused() {
+		t.Fatalf("independent drafts/focus: Alice=%q Bob=%q", alice.input, bob.input)
+	}
+	if windows.Open(ctx, " alice ") != alice || len(manager.overlays) != 2 {
+		t.Fatal("opening the same recipient duplicated the conversation")
+	}
+	app.Window().HandleEvent(uitest.KeyType(event.KeyA, 'a', event.ModNone))
+	windows.AddIncoming(ctx, "Bob", "hello")
+	windows.AddIncoming(ctx, "Alice", "message while typing")
+	windows.AddIncoming(ctx, "Carol", "new conversation")
+	if !alice.inputField.IsFocused() || bob.inputField.IsFocused() || windows.Find("Carol").inputField.IsFocused() {
+		t.Fatal("incoming message stole keyboard focus")
+	}
+	app.Window().HandleEvent(uitest.KeyType(event.KeyC, 'c', event.ModNone))
+	if alice.input != "aac" || bob.input != "b" {
+		t.Fatal("incoming message redirected typing to a different recipient")
+	}
+	// The queued submit must be drained even while the pointer is over another window.
+	windows.Open(ctx, "Bob")
+	ctx.Input.SetMousePosition(alice.x+5, alice.y+40)
+	app.Window().HandleEvent(uitest.KeyPress(event.KeyEnter, event.ModNone))
+	ctx.Input.SetKey(input.KeyEnter, true)
+	consumed, action := windows.Update(ctx)
+	if !consumed || action.Target != "Bob" || action.Message != "b" {
+		t.Fatalf("submit went to the wrong conversation: %+v", action)
+	}
+	if _, duplicate := windows.Update(ctx); duplicate.Target != "" {
+		t.Fatalf("Enter submitted twice: %+v", duplicate)
+	}
+	ctx.Input.ResetKeyboard()
+	alice.Close()
+	if windows.Open(ctx, "Alice") != alice || alice.input != "aac" || len(bob.lines) != 1 {
+		t.Fatal("closing/reopening a conversation lost a draft or another conversation")
+	}
+	before := append([]widget.Widget(nil), manager.overlays...)
+	windows.Rebind(ctx)
+	for i, root := range before {
+		if manager.overlays[i] != root {
+			t.Fatal("whisper rebind changed stacking order")
+		}
+	}
+	if !alice.inputField.IsFocused() || bob.inputField.IsFocused() {
+		t.Fatal("whisper rebind changed the focused conversation")
+	}
+	ctx.Input.SetKey(input.KeyEscape, true)
+	windows.Update(ctx)
+	if alice.IsOpen() || alice.inputField.IsFocused() || !bob.IsOpen() {
+		t.Fatal("Escape did not close and blur only the top conversation")
+	}
+}
+
+func TestNewWindowPlacementStaysOnScreen(t *testing.T) {
+	ctx, _, _ := newWindowInstanceTest()
+	for range 40 {
+		w := NewWindow(300, 428)
+		w.Open(ctx, primitives.Box())
+		w.Publish(ctx)
+		bounds := geometry.NewRect(float32(w.x), float32(w.y), float32(w.width), float32(w.height))
+		if bounds.Min.X < windowScreenMargin || bounds.Min.Y < windowScreenMargin || bounds.Max.X > float32(ctx.ScreenW-windowScreenMargin) || bounds.Max.Y > float32(ctx.ScreenH-windowScreenMargin) {
+			t.Fatalf("window escaped screen bounds: %v", bounds)
+		}
+	}
+}

--- a/ui/window_instances_test.go
+++ b/ui/window_instances_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogpu/ui/widget"
 	"github.com/kivutar/goro/db"
 	"github.com/kivutar/goro/input"
+	"github.com/kivutar/goro/network"
 	"github.com/kivutar/goro/res"
 	"github.com/kivutar/goro/session"
 )
@@ -175,6 +176,73 @@ func TestWindowPollingRespectsStackingAndEscape(t *testing.T) {
 	}
 	if manager.TopEscapeOverlay() != upper.published {
 		t.Fatal("closed window remained in the Escape stack")
+	}
+}
+
+func TestShopYieldsEscapeToTopWindowWhileHovered(t *testing.T) {
+	for _, mode := range []string{"buy", "sell", "deal"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, _, _ := newWindowInstanceTest()
+			var shop ShopWindow
+			hovered := &shop.buyWindow
+			switch mode {
+			case "buy":
+				shop.OpenBuy(nil, ctx)
+			case "sell":
+				shop.OpenSell(nil, ctx)
+			case "deal":
+				shop.OpenDeal(network.ShopDealSelection{NPCID: 1}, ctx)
+				hovered = &shop.dealWindow
+			}
+			var skills SkillWindow
+			skills.OpenWindow(ctx)
+			ctx.Input.SetMousePosition(hovered.x+10, hovered.y+10)
+			ctx.Input.SetKey(input.KeyEscape, true)
+			// WorldMode visits the shop before Skills and stops on consumption.
+			if shop.Update(ctx, nil) {
+				t.Fatal("hovered shop swallowed Escape for the top skill window")
+			}
+			if !skills.Update(ctx, nil, nil) || skills.IsOpen() || !shop.KeyboardShortcutsBlocked() {
+				t.Fatal("Escape did not close only the skill window")
+			}
+			ctx.Input.ResetKeyboard()
+			ctx.Input.SetKey(input.KeyEscape, true)
+			if !shop.Update(ctx, nil) || shop.KeyboardShortcutsBlocked() {
+				t.Fatal("next Escape did not close the shop")
+			}
+		})
+	}
+}
+
+func TestVendingYieldsEscapeToTopWindowWhileHovered(t *testing.T) {
+	for _, mode := range []string{"setup", "buy", "own"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, _, _ := newWindowInstanceTest()
+			var vending VendingWindow
+			switch mode {
+			case "setup":
+				vending.OpenSetup(ctx, network.VendingOpenRequest{MaxItems: 3})
+			case "buy":
+				vending.OpenBuy(ctx, network.VendingItemList{OwnerAID: 1})
+			case "own":
+				vending.ApplyOwnList(ctx, network.VendingItemList{OwnerAID: 1})
+			}
+			var skills SkillWindow
+			skills.OpenWindow(ctx)
+			ctx.Input.SetMousePosition(vending.leftWindow.x+10, vending.leftWindow.y+10)
+			ctx.Input.SetKey(input.KeyEscape, true)
+			if vending.Update(ctx, nil) {
+				t.Fatal("hovered vending window swallowed Escape for the top skill window")
+			}
+			if !skills.Update(ctx, nil, nil) || skills.IsOpen() || !vending.KeyboardShortcutsBlocked() {
+				t.Fatal("Escape did not close only the skill window")
+			}
+			ctx.Input.ResetKeyboard()
+			ctx.Input.SetKey(input.KeyEscape, true)
+			if !vending.Update(ctx, nil) || vending.KeyboardShortcutsBlocked() {
+				t.Fatal("next Escape did not close the vending windows")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Opening another item description, card illustration, or whisper conversation previously reused a single object. Add independent item descriptions and artwork, plus one whisper conversation per recipient with its own history, draft, and focus. Inspecting a slotted card preserves its equipment description.

Reuse the existing window and overlay manager for stacking, placement, dragging, focus, and Escape. Retain single book readers and server transactions. Escape follows the visible stack and runs the title-bar cancellation action; shop and vending wrappers yield it to higher windows even while hovered. Collections survive map transitions.

The client audit and live checklist are in `docs/window-instances.md`. Multiple descriptions/artwork are a quality-of-life extension of the checked clones; whisper conversations follow roBrowser's existing model. Unnamed server whisper errors stay in the main chat because replies cannot reliably be assigned to a recipient.

Validation passed on Linux with `CGO_ENABLED=0` and `-tags nofakecgo`: `go test ./...`, `go vet ./...`, and `staticcheck ./...`. Regression tests cover independent instances, card/book UI events, focus and drafts, map transitions, all six shop/vending Escape modes, and cancellation packets.

Known follow-up: opening a slotted-card description can leave the equipment's card tooltip visible after the pointer moves away. Live game checks in the audit remain outstanding.
